### PR TITLE
Escape html for `get_search_query()` in page title

### DIFF
--- a/search.php
+++ b/search.php
@@ -16,7 +16,7 @@ get_header(); ?>
 		if ( have_posts() ) : ?>
 
 			<header class="page-header">
-				<h1 class="page-title"><?php printf( __( 'Search Results for: %s', 'twentyseventeen' ), '<span>' . get_search_query() . '</span>' ); ?></h1>
+				<h1 class="page-title"><?php printf( __( 'Search Results for: %s', 'twentyseventeen' ), '<span>' . esc_html( get_search_query() ) . '</span>' ); ?></h1>
 			</header>
 			<?php
 			/* Start the Loop */


### PR DESCRIPTION
Fix for #1

@juanfra in .org
