### PR TITLE
Fixed duplicated escaping for post_class()

### DIFF
--- a/components/page/content-front-page-panels.php
+++ b/components/page/content-front-page-panels.php
@@ -12,7 +12,7 @@ $panel_layout = get_theme_mod( $current_panel_layout, 'one-column' );
 
 ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class( 'twentyseventeen-panel ' . esc_attr( $panel_layout ) ); ?> >
+<article id="post-<?php the_ID(); ?>" <?php post_class( 'twentyseventeen-panel ' . $panel_layout ); ?> >
 
 	<span class="panel twentyseventeen-panel<?php echo esc_attr( $twentyseventeencounter ); ?>" id="panel<?php echo esc_attr( $twentyseventeencounter ); ?>">
 		<span class="twentyseventeen-panel-title"><?php printf( __( 'Panel %1$s', 'twentyseventeen' ), esc_attr( $twentyseventeencounter ) ); ?></span>


### PR DESCRIPTION
[`get_post_class()`](https://developer.wordpress.org/reference/functions/get_post_class/) already apply `esc_attr()` for each class.

Here a test:

```
$ wp shell
wp> get_post_class( 'testing <script>alert(1)</script>', 1 )
=> array(9) {
  [0]=>
  string(7) "testing"
  [1]=>
  string(37) "&lt;script&gt;alert(1)&lt;/script&gt;"
  [2]=>
  string(6) "post-1"
  [3]=>
  string(4) "post"
  [4]=>
  string(9) "type-post"
  [5]=>
  string(14) "status-publish"
  [6]=>
  string(15) "format-standard"
  [7]=>
  string(6) "hentry"
  [8]=>
  string(22) "category-sem-categoria"
}
```

wp.org username: claudiosanches
