### PR TITLE
Fix issue with social menu using default left-margin

### DIFF
--- a/style.css
+++ b/style.css
@@ -1691,6 +1691,7 @@ h2.widget-title {
 .social-navigation ul {
 	list-style: none;
 	margin-bottom: 0;
+	margin-left: 0;
 }
 
 .social-navigation li {


### PR DESCRIPTION
It thows off the center alignment of the social menu. 

WordPress.org username - williampatton
