### PR TITLE
Use Markdown for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # Twenty Seventeen
 
-**Contributors:** the WordPress team
-**Requires at least:** WordPress 4.4
-**Tested up to:** WordPress 4.7
-**Version:** 1.0
-**License:** GPLv2 or later
-**License URI:** http://www.gnu.org/licenses/gpl-2.0.html
-**Tags:**
+**Contributors:** the WordPress team  
+**Requires at least:** WordPress 4.4  
+**Tested up to:** WordPress 4.7  
+**Version:** 1.0  
+**License:** GPLv2 or later  
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
+**Tags:**  
+
+
+## Description
+
+Description
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,14 @@
-=== Twenty Seventeen ===
+# Twenty Seventeen
 
-Contributors: wordpressdotorg
-Tags:
+**Contributors:** the WordPress team
+**Requires at least:** WordPress 4.4
+**Tested up to:** WordPress 4.7
+**Version:** 1.0
+**License:** GPLv2 or later
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html
+**Tags:**
 
-Requires at least: 4.0
-Tested up to: 4.7
-Stable tag: 1.0
-License: GPLv2 or later
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
-
-== Description ==
-
-Description
-
-== Installation ==
+## Installation
 
 1. In your admin panel, go to Appearance -> Themes and click the 'Add New' button.
 2. Type in Twenty Seventeen in the search form and press the 'Enter' key on your keyboard.
@@ -21,7 +16,8 @@ Description
 4. Go to https://codex.wordpress.org/Twenty_Seventeen for a guide on how to customize this theme.
 5. Navigate to Appearance > Customize in your admin panel and customize to taste.
 
-== Copyright ==
+
+## Copyright
 
 Twenty Seventeen WordPress Theme, Copyright 2016 WordPress.org
 Twenty Seventeen is distributed under the terms of the GNU GPL
@@ -43,14 +39,16 @@ Licenses: MIT/GPL2
 Source: https://github.com/aFarkas/html5shiv
 
 normalize.css, Copyright 2012-2016 Nicolas Gallagher and Jonathan Neal
-License: MIT
+**License:** MIT
 Source: https://necolas.github.io/normalize.css/
 
 Genericons icon font, Copyright 2013-2016 Automattic.com
-License: GNU GPL, Version 2 (or later)
+**License:** GNU GPL, Version 2 (or later)
 Source: https://genericons.com/
 
-== Changelog ==
 
-= 1.0 -  =
+## Changelog
+
+
+### 1.0 -
 * Initial release


### PR DESCRIPTION
As suggested by @Otto42 ([reference](https://make.wordpress.org/core/2016/09/09/twenty-seventeen-kickoff-meeting-notes/#comment-31121))

> Go ahead and change the readme.txt to a readme.md for github. Make it friendly. The themes directory doesn’t care about readme files at the moment anyway.

[Demo](https://github.com/josephfusco/twentyseventeen/blob/eaeb29eca89570a80de00915b2e33b4d42713ee5/README.md)

WordPress Username: [joefusco](https://profiles.wordpress.org/joefusco)
