### PR TITLE
Fix `aria-label` missing for top menu issue

### DIFF
--- a/components/navigation/navigation-top.php
+++ b/components/navigation/navigation-top.php
@@ -1,4 +1,4 @@
-<nav id="site-navigation" class="main-navigation" role="navigation">
+<nav id="site-navigation" class="main-navigation" role="navigation" aria-label="<?php _e( 'Top Menu', 'twentyseventeen' ); ?>">
 	<button class="menu-toggle" aria-controls="top-menu" aria-expanded="false"><?php _e( 'Menu', 'twentyseventeen' ); ?></button>
 	<?php wp_nav_menu( array(
 		'theme_location' => 'top',


### PR DESCRIPTION
Fixes https://github.com/WordPress/twentyseventeen/issues/79

WordPress Username: [manishsongirkar36](https://profiles.wordpress.org/manishsongirkar36)
