### PR TITLE
Dublication selector for class header-top removed from global.js

### DIFF
--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -1,7 +1,7 @@
 jQuery( document ).ready( function( $ ) {
 
 	var $header = $( '.header-top' ),
-		$headerHeight = $( '.header-top' ).outerHeight(),
+		$headerHeight = $header.outerHeight(),
 		$headerOffset = $( '.custom-header' ).outerHeight(),
 		$headerHiddenClass = 'site-header-hidden',
 		$headerFixedClass = 'site-header-fixed';


### PR DESCRIPTION
wp.org username: codersantosh
