### PR TITLE
Remove the animation when “docking” the menu

### DIFF
--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -19,7 +19,7 @@ jQuery( document ).ready( function( $ ) {
 		if ( 'none' === $( '.menu-toggle' ).css( 'display' ) ) {
 
 			// When there's a custom header image, the header offset includes the height of the navigation
-			$navigationHeight = $navigation.innerHeight();
+			$navigationHeight = $navigation.outerHeight();
 			if ( $( '.custom-header-image' ).length ) {
 				$headerOffset = $( '.custom-header' ).innerHeight() - $navigationHeight;
 			} else {
@@ -41,7 +41,7 @@ jQuery( document ).ready( function( $ ) {
 
 	function adjustHeaderHeight() {
 
-		$navigationHeight = $navigation.innerHeight();
+		$navigationHeight = $navigation.outerHeight();
 
 		if ( 'none' === $( '.menu-toggle' ).css( 'display' ) ) {
 			$branding.css( 'margin-bottom', $navigationHeight );

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -6,7 +6,6 @@ jQuery( document ).ready( function( $ ) {
 	var $body = $( 'body' ),
 		$navigation = $( '.navigation-top' ),
 		$branding = $( '.site-branding' ),
-		$navigationHiddenClass = 'site-navigation-hidden',
 		$navigationFixedClass = 'site-navigation-fixed',
 		$headerOffset,
 		$navigationHeight,
@@ -27,23 +26,15 @@ jQuery( document ).ready( function( $ ) {
 				$headerOffset = $( '.custom-header' ).innerHeight();
 			}
 
-			if ( $( window ).scrollTop() <= $headerOffset && $navigation.hasClass( $navigationFixedClass ) ) {
+			if ( $( window ).scrollTop() >= $headerOffset ) {
 
-				// If the navigation is just offscreen, add hidden class and make sure fixed class is removed
-				$navigation.removeClass( $navigationFixedClass );
-				$navigation.addClass( $navigationHiddenClass );
-
-			} else if ( $( window ).scrollTop() >= $headerOffset ) {
-
-				// Otherwise, if the scroll is more than the custom header, switch navigation to 'fixed' class
+				// If the scroll is more than the custom header, switch navigation to 'fixed' class
 				$navigation.addClass( $navigationFixedClass );
-				$navigation.removeClass( $navigationHiddenClass );
 
 			} else {
 
 				// In all other cases, remove both classes
 				$navigation.removeClass( $navigationFixedClass );
-				$navigation.removeClass( $navigationHiddenClass );
 			}
 		}
 	}

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -19,17 +19,23 @@ jQuery( document ).ready( function( $ ) {
 		// Make sure we're not on a mobile screen
 		if ( 'none' === $( '.menu-toggle' ).css( 'display' ) ) {
 
-			$headerOffset = $( '.custom-header' ).innerHeight();
+			// When there's a custom header image, the header offset includes the height of the navigation
+			$navigationHeight = $navigation.innerHeight();
+			if ( $( '.custom-header-image' ).length ) {
+				$headerOffset = $( '.custom-header' ).innerHeight() - $navigationHeight;
+			} else {
+				$headerOffset = $( '.custom-header' ).innerHeight();
+			}
 
 			if ( $( window ).scrollTop() <= $headerOffset && $navigation.hasClass( $navigationFixedClass ) ) {
 
-				 // If the navigation is just offscreen, add hidden class and make sure fixed class is removed
+				// If the navigation is just offscreen, add hidden class and make sure fixed class is removed
 				$navigation.removeClass( $navigationFixedClass );
 				$navigation.addClass( $navigationHiddenClass );
 
 			} else if ( $( window ).scrollTop() >= $headerOffset ) {
 
-				 // Otherwise, if the scroll is more than the custom header, switch navigation to 'fixed' class
+				// Otherwise, if the scroll is more than the custom header, switch navigation to 'fixed' class
 				$navigation.addClass( $navigationFixedClass );
 				$navigation.removeClass( $navigationHiddenClass );
 
@@ -57,7 +63,7 @@ jQuery( document ).ready( function( $ ) {
 	 * 'Scroll Down' arrow in menu area
 	 */
 	if ( $( 'body' ).hasClass( 'admin-bar' ) ) {
-		$menuTop = -32	;
+		$menuTop = -32;
 	}
 	$( '.menu-scroll-down' ).click( function( e ) {
 		e.preventDefault();

--- a/style.css
+++ b/style.css
@@ -2719,8 +2719,7 @@ article.panel-placeholder {
 		padding: 0.75em 0;
 	}
 
-	.site-navigation-fixed.navigation-top,
-	.site-navigation-hidden.navigation-top {
+	.site-navigation-fixed.navigation-top {
 		bottom: auto;
 		position: fixed;
 		left: 0;
@@ -2730,8 +2729,7 @@ article.panel-placeholder {
 		z-index: 7;
 	}
 
-	.admin-bar .site-navigation-fixed.navigation-top,
-	.admin-bar .site-navigation-hidden.navigation-top {
+	.admin-bar .site-navigation-fixed.navigation-top {
 		top: 32px;
 	}
 
@@ -2885,8 +2883,7 @@ article.panel-placeholder {
 		display: none;
 	}
 
-	.site-navigation-fixed .menu-scroll-down,
-	.site-navigation-hidden .menu-scroll-down {
+	.site-navigation-fixed .menu-scroll-down {
 		display: none;
 	}
 

--- a/style.css
+++ b/style.css
@@ -2735,66 +2735,6 @@ article.panel-placeholder {
 		top: 32px;
 	}
 
-	.site-navigation-fixed.navigation-top .wrap,
-	.site-navigation-hidden.navigation-top .wrap {
-		padding-bottom: 0.25em;
-		padding-top: 0.25em;
-	}
-
-	.site-navigation-fixed.navigation-top {
-		-webkit-animation: navigation-down 0.2s ease-in;
-		animation: navigation-down 0.2s ease-in;
-		-webkit-transform: translate(0);
-		transform: translate(0);
-	}
-
-	.site-navigation-hidden.navigation-top {
-		-webkit-animation: navigation-up 0.5s ease-in;
-		animation: navigation-up 0.5s ease-in;
-		-webkit-transform: translate(-100%);
-		transform: translate(-100%);
-	}
-
-	@-webkit-keyframes navigation-down {
-		from {
-			-webkit-transform: translate(0, -100%);
-		}
-
-		to {
-			-webkit-transform: translate(0);
-		}
-	}
-
-	@keyframes navigation-down {
-		from {
-			transform: translate(0, -100%);
-		}
-
-		to {
-			transform: translate(0);
-		}
-	}
-
-	@-webkit-keyframes navigation-up {
-		from {
-			-webkit-transform: translate(0);
-		}
-
-		to {
-			-webkit-transform: translate(0, -100%);
-		}
-	}
-
-	@keyframes navigation-up {
-		from {
-			transform: translate(0);
-		}
-
-		to {
-			transform: translate(0, -100%);
-		}
-	}
-
 	/* Main Navigation */
 
 	.js .menu-toggle,
@@ -2834,12 +2774,6 @@ article.panel-placeholder {
 
 	.main-navigation a {
 		padding: 1em 1.25em;
-	}
-
-	.site-navigation-fixed.navigation-top .main-navigation a,
-	.site-navigation-hidden.navigation-top .main-navigation a {
-		padding-bottom: 0.75em;
-		padding-top: 0.75em;
 	}
 
 	.main-navigation ul ul {


### PR DESCRIPTION
I was chatting with @melchoyce about the menu docking on scroll, and we thought this was a smoother (less distracting) experience -- no bounce animation, and the menu stays the same height.

wp.org username: ryelle 
