### PR TITLE
Update style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -2717,7 +2717,7 @@ article.panel-placeholder {
 
 	.admin-bar .site-navigation-fixed.navigation-top,
 	.admin-bar .site-navigation-hidden.navigation-top {
-		top: 32px;
+		top: 46px;
 	}
 
 	.site-navigation-fixed.navigation-top .wrap,


### PR DESCRIPTION
The default WordPress admin bar height is 46px, and we give top 32px to the menubar we need to give this 46px, means when menu is fixed then it will get top 46px and not overlap with the admin bar.
