### PR TITLE
h1 heading size from em to rem

### DIFF
--- a/style.css
+++ b/style.css
@@ -433,7 +433,7 @@ h6:first-child {
 
 h1 {
 	font-size: 24px;
-	font-size: 1.5em;
+	font-size: 1.5rem;
 	font-weight: 300;
 }
 


### PR DESCRIPTION
suggested correction for style.css:
typo in style.css for h1 size: em instead of rem as for other headings
