### PR TITLE
Social navigation: Add fallback icon for unsupported links.

### DIFF
--- a/style.css
+++ b/style.css
@@ -2113,6 +2113,7 @@ h2.widget-title {
 	-webkit-transition: background-color 0.2s ease-in-out;
 	transition: background-color 0.2s ease-in-out;
 	width: 40px;
+	content: "\f107"; /* Fallback for unsupported links */
 }
 
 .social-navigation a:hover:before,


### PR DESCRIPTION
Does what the title says. Uses `genericon-link` for unsupported links in social menu. Resolves #191 
