### PR TITLE
Fixed: Li footer widget lacks padding

### DIFF
--- a/style.css
+++ b/style.css
@@ -1906,10 +1906,6 @@ h2.widget-title {
 	padding: 0.5em 0;
 }
 
-.widget ul li:last-child {
-	padding-bottom: 0;
-}
-
 .widget ul li + li {
 	margin-top: -1px;
 }


### PR DESCRIPTION
Removed padding style property for last li item for footer widget. 

Fixes #158 
