### PR TITLE
Fix image jiggle

### DIFF
--- a/style.css
+++ b/style.css
@@ -922,6 +922,7 @@ a:hover .nav-title,
 }
 
 .post-thumbnail a img {
+	-webkit-backface-visibility: hidden;
 	-webkit-transition: opacity 0.2s;
 	transition: opacity 0.2s;
 }


### PR DESCRIPTION
Fixes #212 

Same issue here: http://stackoverflow.com/questions/12980153/image-moves-on-hover-chrome-opacity-issue

I have included _only_ the prefixed version of `backface-visibility` as this just happens in Chrome.

wp.org username: [joefusco](https://profiles.wordpress.org/joefusco)
