### PR TITLE
Make sure custom header image appears on front page when it's set to display blog posts

### DIFF
--- a/components/header/header-image.php
+++ b/components/header/header-image.php
@@ -13,7 +13,7 @@
 	<?php
 
 		// If front page.
-		if ( twentyseventeen_is_frontpage() ) :
+		if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) :
 
 			// Check if Custom Header image has been added
 			$header_image = get_header_image();
@@ -22,7 +22,7 @@
 				<div class="custom-header-image" style="background-image: url(<?php echo esc_url( $header_image ); ?>)"></div>
 				<?php get_template_part( 'components/header/site', 'branding' ); ?>
 
-			<?php elseif ( has_post_thumbnail() ) :
+			<?php elseif ( twentyseventeen_is_frontpage() && has_post_thumbnail() ) :
 				// If not, fall back to front page's featured image
 				$post_thumbnail_id = get_post_thumbnail_id( $post->ID );
 				$thumbnail_attributes = wp_get_attachment_image_src( $post_thumbnail_id, 'twentyseventeen-featured-image' );

--- a/components/navigation/navigation-top.php
+++ b/components/navigation/navigation-top.php
@@ -16,7 +16,7 @@
 		'menu_id'        => 'top-menu',
 	) ); ?>
 
-	<?php if( twentyseventeen_is_frontpage() ) : ?>
+	<?php if( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) : ?>
 		<button class="menu-scroll-down"><span class="screen-reader-text"><?php _e( 'Scroll Down', 'twentyseventeen' ); ?></span></button>
 	<?php endif; ?>
 </nav><!-- #site-navigation -->

--- a/functions.php
+++ b/functions.php
@@ -248,7 +248,7 @@ function twentyseventeen_scripts() {
 	}
 
 	// Scroll effects (only loaded on front page).
-	if ( twentyseventeen_is_frontpage() ) {
+	if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) {
 		wp_enqueue_script( 'jquery-scrollto', get_template_directory_uri() . '/assets/js/jquery.scrollTo.js', array( 'jquery' ), '20151030', true );
 	}
 

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -28,7 +28,7 @@ function twentyseventeen_custom_header_setup() {
 		'default-image' => array(
 			'url'           => '%s/assets/images/header.jpg',
 			'thumbnail_url' => '%s/assets/images/header.jpg',
-			'description'   => __( 'Default Header Image', 'twentyseventeen' )
+			'description'   => __( 'Default Header Image', 'twentyseventeen' ),
 		),
 	) );
 }

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -23,6 +23,14 @@ function twentyseventeen_custom_header_setup() {
 		'flex-height'        => true,
 		'wp-head-callback'   => 'twentyseventeen_header_style',
 	) ) );
+
+	register_default_headers( array(
+		'default-image' => array(
+			'url'           => '%s/assets/images/header.jpg',
+			'thumbnail_url' => '%s/assets/images/header.jpg',
+			'description'   => __( 'Default Header Image', 'twentyseventeen' )
+		),
+	) );
 }
 add_action( 'after_setup_theme', 'twentyseventeen_custom_header_setup' );
 

--- a/style.css
+++ b/style.css
@@ -993,7 +993,8 @@ body {
 	transition: margin-bottom 0.2s;
 }
 
-.twentyseventeen-front-page:not(.no-header-image) .site-branding {
+.twentyseventeen-front-page:not(.no-header-image) .site-branding,
+.home.blog:not(.no-header-image) .site-branding {
 	bottom: 0;
 	position: absolute;
 	width: 100%;
@@ -1027,7 +1028,9 @@ body {
 }
 
 .twentyseventeen-front-page:not(.no-header-image) .site-title,
-.twentyseventeen-front-page:not(.no-header-image) .site-title a {
+.twentyseventeen-front-page:not(.no-header-image) .site-title a,
+.home.blog:not(.no-header-image) .site-title,
+.home.blog:not(.no-header-image) .site-title a {
 	color: #fff;
 }
 
@@ -1038,7 +1041,8 @@ body {
 	margin-bottom: 0;
 }
 
-.twentyseventeen-front-page:not(.no-header-image) .site-description {
+.twentyseventeen-front-page:not(.no-header-image) .site-description,
+.home.blog:not(.no-header-image) .site-description {
 	color: #bbb;
 }
 
@@ -2688,7 +2692,8 @@ article.panel-placeholder {
 		max-width: 400px;
 	}
 
-	.twentyseventeen-front-page:not(.no-header-image) .custom-logo-link img {
+	.twentyseventeen-front-page:not(.no-header-image) .custom-logo-link img,
+	.home.blog:not(.no-header-image) .custom-logo-link img {
 		max-height: 500px;
 		max-width: 500px;
 	}
@@ -2980,13 +2985,15 @@ article.panel-placeholder {
 
 	/* Front Page */
 
-	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image {
+	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
+	.home.blog:not(.no-header-image) .custom-header-image {
 		height: 1200px;
 		height: 100vh;
 		max-height: 100%;
 	}
 
-	.admin-bar.twentyseventeen-front-page:not(.no-header-image) .custom-header-image {
+	.admin-bar.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
+	.admin-bar.home.blog:not(.no-header-image) .custom-header-image {
 		height: calc( 100vh - 32px );
 	}
 
@@ -3308,7 +3315,8 @@ article.panel-placeholder {
 		background-attachment: fixed;
 	}
 
-	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image {
+	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
+	.home.blog:not(.no-header-image) .custom-header-image {
 		background-attachment: fixed;
 	}
 


### PR DESCRIPTION
Currently the custom header image only appears on a static front page, but it does not show up when a user sets the front page to display blog posts. 

This should make the custom header image appear on whatever is set to be the site's front page, whether it's a static page or blog posts. 

Fixes #132.
