### PR TITLE
Add custom sizes attributes to responsive images

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -273,7 +273,7 @@ function twentyseventeen_content_image_sizes_attr( $sizes, $size ) {
 	740 <= $width && $sizes = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, 740px';
 
 	if ( is_active_sidebar( 'sidebar-1' ) || is_archive() || is_search() || is_home() || is_page() ) {
-		if ( !( is_page() && 'one-column' === get_theme_mod( 'twentyseventeen_page_options' ) ) ) {
+		if ( ! ( is_page() && 'one-column' === get_theme_mod( 'twentyseventeen_page_options' ) ) ) {
 			767 <= $width && $sizes = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
 		}
 	}

--- a/functions.php
+++ b/functions.php
@@ -272,8 +272,10 @@ function twentyseventeen_content_image_sizes_attr( $sizes, $size ) {
 
 	740 <= $width && $sizes = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, 740px';
 
-	if ( is_active_sidebar( 'sidebar-1' ) || is_archive() || is_search() || is_home() ) {
-		767 <= $width && $sizes = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
+	if ( is_active_sidebar( 'sidebar-1' ) || is_archive() || is_search() || is_home() || is_page() ) {
+		if ( !( is_page() && 'one-column' === get_theme_mod( 'twentyseventeen_page_options' ) ) ) {
+			767 <= $width && $sizes = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
+		}
 	}
 
 	return $sizes;
@@ -293,7 +295,7 @@ add_filter( 'wp_calculate_image_sizes', 'twentyseventeen_content_image_sizes_att
  */
 function twentyseventeen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
 	if ( is_archive() || is_search() || is_home() ) {
-		$attr['sizes'] = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, 740px';
+		$attr['sizes'] = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
 	} else {
 		$attr['sizes'] = '100vw';
 	}

--- a/functions.php
+++ b/functions.php
@@ -273,7 +273,7 @@ function twentyseventeen_content_image_sizes_attr( $sizes, $size ) {
 	740 <= $width && $sizes = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, 740px';
 
 	if ( is_active_sidebar( 'sidebar-1' ) || is_archive() || is_search() || is_home() || is_page() ) {
-		if ( ! ( is_page() && 'one-column' === get_theme_mod( 'twentyseventeen_page_options' ) ) ) {
+		if ( ! ( is_page() && 'one-column' === get_theme_mod( 'page_options' ) ) ) {
 			767 <= $width && $sizes = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
 		}
 	}

--- a/functions.php
+++ b/functions.php
@@ -270,7 +270,6 @@ add_action( 'wp_enqueue_scripts', 'twentyseventeen_scripts' );
 function twentyseventeen_content_image_sizes_attr( $sizes, $size ) {
 	$width = $size[0];
 
-	//if ( 'page' === get_post_type() || ( ! is_active_sidebar( 'sidebar-1' ) && is_single() ) ) {}
 	740 <= $width && $sizes = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, 740px';
 
 	if ( is_active_sidebar( 'sidebar-1' ) || is_archive() || is_search() || is_home() ) {

--- a/functions.php
+++ b/functions.php
@@ -255,6 +255,54 @@ function twentyseventeen_scripts() {
 }
 add_action( 'wp_enqueue_scripts', 'twentyseventeen_scripts' );
 
+
+/**
+ * Add custom image sizes attribute to enhance responsive image functionality
+ * for content images
+ *
+ * @since Twenty Seventeen 1.0
+ *
+ * @param string $sizes A source size value for use in a 'sizes' attribute.
+ * @param array  $size  Image size. Accepts an array of width and height
+ *                      values in pixels (in that order).
+ * @return string A source size value for use in a content image 'sizes' attribute.
+ */
+function twentyseventeen_content_image_sizes_attr( $sizes, $size ) {
+	$width = $size[0];
+
+	//if ( 'page' === get_post_type() || ( ! is_active_sidebar( 'sidebar-1' ) && is_single() ) ) {}
+	740 <= $width && $sizes = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, 740px';
+
+	if ( is_active_sidebar( 'sidebar-1' ) || is_archive() || is_search() || is_home() ) {
+		767 <= $width && $sizes = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
+	}
+
+	return $sizes;
+}
+add_filter( 'wp_calculate_image_sizes', 'twentyseventeen_content_image_sizes_attr', 10 , 2 );
+
+/**
+ * Add custom image sizes attribute to enhance responsive image functionality
+ * for post thumbnails
+ *
+ * @since Twenty Seventeen 1.0
+ *
+ * @param array $attr Attributes for the image markup.
+ * @param int   $attachment Image attachment ID.
+ * @param array $size Registered image size or flat array of height and width dimensions.
+ * @return string A source size value for use in a post thumbnail 'sizes' attribute.
+ */
+function twentyseventeen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
+	if ( is_archive() || is_search() || is_home() ) {
+		$attr['sizes'] = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, 740px';
+	} else {
+		$attr['sizes'] = '100vw';
+	}
+	return $attr;
+}
+add_filter( 'wp_get_attachment_image_attributes', 'twentyseventeen_post_thumbnail_sizes_attr', 10 , 3 );
+
+
 /**
  * Implement the Custom Header feature.
  */


### PR DESCRIPTION
Adds control of `sizes` attribute in responsive images to reflect actual displayed size, not only full viewport width. Fixes #120 
