### PR TITLE
Adding smaller image size

### DIFF
--- a/components/post/content-audio.php
+++ b/components/post/content-audio.php
@@ -35,7 +35,7 @@
 	<?php if ( '' !== get_the_post_thumbnail() ) : ?>
 		<div class="post-thumbnail">
 			<a href="<?php the_permalink(); ?>">
-				<?php the_post_thumbnail( 'twentyseventeen-featured-image' ); ?>
+				<?php the_post_thumbnail( 'twentyseventeen-small-featured-image' ); ?>
 			</a>
 		</div><!-- .post-thumbnail -->
 	<?php endif; ?>

--- a/components/post/content-gallery.php
+++ b/components/post/content-gallery.php
@@ -35,7 +35,7 @@
 	<?php if ( '' !== get_the_post_thumbnail() ) : ?>
 		<div class="post-thumbnail">
 			<a href="<?php the_permalink(); ?>">
-				<?php the_post_thumbnail( 'twentyseventeen-featured-image' ); ?>
+				<?php the_post_thumbnail( 'twentyseventeen-small-featured-image' ); ?>
 			</a>
 		</div><!-- .post-thumbnail -->
 	<?php endif; ?>

--- a/components/post/content-image.php
+++ b/components/post/content-image.php
@@ -35,7 +35,7 @@
 	<?php if ( '' !== get_the_post_thumbnail() ) : ?>
 		<div class="post-thumbnail">
 			<a href="<?php the_permalink(); ?>">
-				<?php the_post_thumbnail( 'twentyseventeen-featured-image' ); ?>
+				<?php the_post_thumbnail( 'twentyseventeen-small-featured-image' ); ?>
 			</a>
 		</div><!-- .post-thumbnail -->
 	<?php endif; ?>

--- a/components/post/content-video.php
+++ b/components/post/content-video.php
@@ -35,7 +35,7 @@
 	<?php if ( '' !== get_the_post_thumbnail() ) : ?>
 		<div class="post-thumbnail">
 			<a href="<?php the_permalink(); ?>">
-				<?php the_post_thumbnail( 'twentyseventeen-featured-image' ); ?>
+				<?php the_post_thumbnail( 'twentyseventeen-small-featured-image' ); ?>
 			</a>
 		</div><!-- .post-thumbnail -->
 	<?php endif; ?>

--- a/components/post/content.php
+++ b/components/post/content.php
@@ -36,7 +36,7 @@
 	<?php if ( '' !== get_the_post_thumbnail() && ! is_single() ) : ?>
 		<div class="post-thumbnail">
 			<a href="<?php the_permalink(); ?>">
-				<?php the_post_thumbnail( 'twentyseventeen-featured-image' ); ?>
+				<?php the_post_thumbnail( 'twentyseventeen-small-featured-image' ); ?>
 			</a>
 		</div><!-- .post-thumbnail -->
 	<?php endif; ?>

--- a/functions.php
+++ b/functions.php
@@ -46,6 +46,8 @@ function twentyseventeen_setup() {
 
 	add_image_size( 'twentyseventeen-featured-image', 2000, 1200, true );
 
+	add_image_size( 'twentyseventeen-small-featured-image', 628, 9999 );
+
 	add_image_size( 'twentyseventeen-thumbnail-avatar', 100, 100, true );
 
 	// This theme uses wp_nav_menu() in two locations.

--- a/functions.php
+++ b/functions.php
@@ -258,6 +258,60 @@ function twentyseventeen_scripts() {
 }
 add_action( 'wp_enqueue_scripts', 'twentyseventeen_scripts' );
 
+
+/**
+ * Add custom image sizes attribute to enhance responsive image functionality
+ * for content images.
+ *
+ * @since Twenty Seventeen 1.0
+ *
+ * @param string $sizes A source size value for use in a 'sizes' attribute.
+ * @param array  $size  Image size. Accepts an array of width and height
+ *                      values in pixels (in that order).
+ * @return string A source size value for use in a content image 'sizes' attribute.
+ */
+function twentyseventeen_content_image_sizes_attr( $sizes, $size ) {
+	$width = $size[0]; // Image width.
+
+	580 <= $width && $sizes = '(max-width: 768px) 628px, (max-width: 880px) 473px, 580px';
+
+	if ( 'one-column' === get_theme_mod( 'page_options' ) ) {
+		740 <= $width && $sizes = '(max-width: 804px) 93vw, 740px';
+	} else {
+		580 > $width && $sizes = '(max-width: ' . $width . 'px) 93vw, ' . $width . 'px';
+	}
+
+	return $sizes;
+}
+add_filter( 'wp_calculate_image_sizes', 'twentyseventeen_content_image_sizes_attr', 10 , 2 );
+
+
+/**
+ * Add custom image sizes attribute to enhance responsive image functionality
+ * for post thumbnails.
+ *
+ * @since Twenty Seventeen 1.0
+ *
+ * @param array $attr Attributes for the image markup.
+ * @param int   $attachment Image attachment ID.
+ * @param array $size Registered image size or flat array of height and width dimensions.
+ * @return string A source size value for use in a post thumbnail 'sizes' attribute.
+ */
+function twentyseventeen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
+
+	if ( 'twentyseventeen-featured-image' === $size ) {
+		$attr['sizes'] = '(max-width: 2000px) 100vw, 2000px';
+	}
+
+	if ( 'twentyseventeen-small-featured-image' === $size ) {
+		$attr['sizes'] = '(max-width: 768px) 628px, (max-width: 880px) 473px, 580px';
+	}
+
+	return $attr;
+}
+add_filter( 'wp_get_attachment_image_attributes', 'twentyseventeen_post_thumbnail_sizes_attr', 10 , 3 );
+
+
 /**
  * Implement the Custom Header feature.
  */

--- a/functions.php
+++ b/functions.php
@@ -260,59 +260,6 @@ add_action( 'wp_enqueue_scripts', 'twentyseventeen_scripts' );
 
 
 /**
- * Add custom image sizes attribute to enhance responsive image functionality
- * for content images.
- *
- * @since Twenty Seventeen 1.0
- *
- * @param string $sizes A source size value for use in a 'sizes' attribute.
- * @param array  $size  Image size. Accepts an array of width and height
- *                      values in pixels (in that order).
- * @return string A source size value for use in a content image 'sizes' attribute.
- */
-function twentyseventeen_content_image_sizes_attr( $sizes, $size ) {
-	$width = $size[0]; // Image width.
-
-	580 <= $width && $sizes = '(max-width: 768px) 628px, (max-width: 880px) 473px, 580px';
-
-	if ( 'one-column' === get_theme_mod( 'page_options' ) ) {
-		740 <= $width && $sizes = '(max-width: 804px) 93vw, 740px';
-	} else {
-		580 > $width && $sizes = '(max-width: ' . $width . 'px) 93vw, ' . $width . 'px';
-	}
-
-	return $sizes;
-}
-add_filter( 'wp_calculate_image_sizes', 'twentyseventeen_content_image_sizes_attr', 10 , 2 );
-
-
-/**
- * Add custom image sizes attribute to enhance responsive image functionality
- * for post thumbnails.
- *
- * @since Twenty Seventeen 1.0
- *
- * @param array $attr Attributes for the image markup.
- * @param int   $attachment Image attachment ID.
- * @param array $size Registered image size or flat array of height and width dimensions.
- * @return string A source size value for use in a post thumbnail 'sizes' attribute.
- */
-function twentyseventeen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
-
-	if ( 'twentyseventeen-featured-image' === $size ) {
-		$attr['sizes'] = '(max-width: 2000px) 100vw, 2000px';
-	}
-
-	if ( 'twentyseventeen-small-featured-image' === $size ) {
-		$attr['sizes'] = '(max-width: 768px) 628px, (max-width: 880px) 473px, 580px';
-	}
-
-	return $attr;
-}
-add_filter( 'wp_get_attachment_image_attributes', 'twentyseventeen_post_thumbnail_sizes_attr', 10 , 3 );
-
-
-/**
  * Implement the Custom Header feature.
  */
 require get_template_directory() . '/inc/custom-header.php';


### PR DESCRIPTION
Adding smaller custom image size for featured images, for when they're displayed on the blog index and archive pages. Adding function to make sure `$sizes` attribute doesn't exceed viewport. 

See #120.
