### PR TITLE
Account for the sticky menu when scrolling down to the content

### DIFF
--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -53,14 +53,15 @@ jQuery( document ).ready( function( $ ) {
 	/**
 	 * 'Scroll Down' arrow in menu area
 	 */
+	$menuTop = -30; // Start with a 30px offset, so the menu doesn't hit the content
 	if ( $( 'body' ).hasClass( 'admin-bar' ) ) {
-		$menuTop = -32;
+		$menuTop -= 32;
 	}
 	$( '.menu-scroll-down' ).click( function( e ) {
 		e.preventDefault();
 		$( window ).scrollTo( '#primary', {
 			duration: 600,
-			offset: { 'top': $menuTop }
+			offset: { 'top': $menuTop - $navigation.outerHeight() }
 		} );
 	} );
 

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -53,7 +53,9 @@ jQuery( document ).ready( function( $ ) {
 	/**
 	 * 'Scroll Down' arrow in menu area
 	 */
-	$menuTop = -30; // Start with a 30px offset, so the menu doesn't hit the content
+	if ( $( 'body' ).hasClass( 'blog' ) ) {
+		$menuTop -= 30; // The div for latest posts has no space above content, add some to account for this
+	}
 	if ( $( 'body' ).hasClass( 'admin-bar' ) ) {
 		$menuTop -= 32;
 	}


### PR DESCRIPTION
When clicking on the "scroll down" arrow in the navigation bar, the scrolled location doesn't account for the sticky menu, and it ends up overlapping content. See:

![before](https://cloud.githubusercontent.com/assets/541093/19333845/f015f8ae-90c5-11e6-8c78-bc3e182810cb.png)
(The post title and search bar are hidden under the sticky menu)

This PR adds the menu's height into the offset, along with a 30px margin (so that menu doesn't sit right on top of the content). This is what it looks like applied:

![after](https://cloud.githubusercontent.com/assets/541093/19333870/222a2f04-90c6-11e6-82bb-505e4ce2aa86.png)
