### PR TITLE
Adding h1 to front page's content panel to improve accessibility

### DIFF
--- a/components/header/site-branding.php
+++ b/components/header/site-branding.php
@@ -14,7 +14,7 @@
 
 		<?php twentyseventeen_the_custom_logo(); ?>
 
-		<?php if ( is_front_page() && is_home() ) : ?>
+		<?php if ( is_front_page() ) : ?>
 			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
 		<?php else : ?>
 			<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>

--- a/components/page/content-front-page.php
+++ b/components/page/content-front-page.php
@@ -14,7 +14,7 @@
 	<div class="panel-content">
 		<div class="wrap">
 			<header class="entry-header">
-				<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+				<?php the_title( '<h2 class="entry-title">', '</h2>' ); ?>
 
 				<?php twentyseventeen_edit_link( get_the_ID() ); ?>
 

--- a/components/page/content-front-page.php
+++ b/components/page/content-front-page.php
@@ -14,7 +14,7 @@
 	<div class="panel-content">
 		<div class="wrap">
 			<header class="entry-header">
-				<?php the_title( '<h2 class="entry-title">', '</h2>' ); ?>
+				<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
 
 				<?php twentyseventeen_edit_link( get_the_ID() ); ?>
 


### PR DESCRIPTION
Adding h1 to front page's content panel to improve accessibility - takes care the issue with the headers.

See #288.
