### PR TITLE
Changing post selector for spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -1473,9 +1473,9 @@ body.page:not(.twentyseventeen-front-page) .entry-title {
 
 /* Blog landing, search, archives */
 
-.blog .post,
-.archive .post,
-.search .hentry {
+.blog .site-main > article,
+.archive .site-main > article,
+.search .site-main > article {
 	padding-bottom: 2em;
 }
 
@@ -3024,9 +3024,9 @@ article.panel-placeholder {
 		width: 58%;
 	}
 
-	.blog .post,
-	.archive .post,
-	.search .hentry {
+	.blog .site-main > article,
+	.archive .site-main > article,
+	.search .site-main > article {
 		padding-bottom: 4em;
 	}
 


### PR DESCRIPTION
Changing selector used for styling posts to a more generic one, so spaces between posts will also be applied to custom post types without the theme needing to use `.hentry`. 

See #208.
