### PR TITLE
Make submenu left aligned

### DIFF
--- a/style.css
+++ b/style.css
@@ -2784,7 +2784,7 @@ article.panel-placeholder {
 		content: "";
 		height: 0;
 		position: absolute;
-		right: 0.5em;
+		left: 0.5em;
 		top: -6px;
 		width: 0;
 	}
@@ -2838,8 +2838,8 @@ article.panel-placeholder {
 
 	.main-navigation ul li:hover > ul,
 	.main-navigation ul li.focus > ul {
-		left: auto;
-		right: 0.5em;
+		left: 0.5em;
+		right: auto;
 	}
 
 	.main-navigation .menu-item-has-children > a:after,


### PR DESCRIPTION
This is a fix for issue #200 

Making submenus (dropdowns) positioned relative to the left of the parent LI rather than to the right. This is a simple change of positioning - none of the other styling or functionality has been changed.

Before:
![image](https://cloud.githubusercontent.com/assets/1842363/19371740/591d6c38-9201-11e6-9f2a-bc7b0298dfc4.png)

After:
![image](https://cloud.githubusercontent.com/assets/1842363/19371748/6d3ce7e8-9201-11e6-8e0c-36193de4fde3.png)
