### PR TITLE
Revised CSS so that images don't float on smaller mobile devices, eve…

### DIFF
--- a/style.css
+++ b/style.css
@@ -2325,6 +2325,12 @@ img {
 	max-width: 100%; /* Adhere to container width. */
 }
 
+img.alignleft,
+img.alignright {
+	float: none;
+	margin: 0;
+}
+
 .page-content .wp-smiley,
 .entry-content .wp-smiley,
 .comment-content .wp-smiley {
@@ -2621,6 +2627,16 @@ article.panel-placeholder {
 	.entry-content blockquote.alignright {
 		font-size: 14px;
 		font-size: 0.875rem;
+	}
+
+	/* Fix image alignment */
+	img.alignleft {
+		float: left;
+		margin-right: 1.5em;
+	}
+	img.alignright {
+		float: right;
+		margin-left: 1.5em;
 	}
 
 	/* Site Branding */


### PR DESCRIPTION
Revised CSS so that images don't float on smaller mobile devices, even with .alignleft or .alignright class. Media query at 30em allows float to happen on them.

Fixes #316 
