### PR TITLE
Adding theme tags to style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,7 +8,7 @@ Version: 1.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentyseventeen
-Tags:
+Tags: one-column, two-column, right-sidebar, flexible-header, accessibility-ready, custom-colors, custom-header, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, post-formats, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready
 
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.


### PR DESCRIPTION
Adding the appropriate theme tags from https://make.wordpress.org/themes/handbook/review/required/theme-tags/. 

See #282.
