### PR TITLE
Fix blockquote alignment on blog index as front page

### DIFF
--- a/rtl.css
+++ b/rtl.css
@@ -412,7 +412,7 @@ input[type="checkbox"] {
 
 	/* blog index and archive */
 
-	.blog:not(.has-sidebar):not(.home) .entry-content blockquote.alignleft,
+	.blog:not(.has-sidebar) .entry-content blockquote.alignleft,
 	.twentyseventeen-front-page .entry-content blockquote.alignleft,
 	.archive:not(.has-sidebar) .entry-content blockquote.alignleft,
 	.page-two-column .entry-content blockquote.alignleft {
@@ -420,7 +420,7 @@ input[type="checkbox"] {
 		width: 34%;
 	}
 
-	.blog:not(.has-sidebar):not(.home) .entry-content blockquote.alignright,
+	.blog:not(.has-sidebar) .entry-content blockquote.alignright,
 	.twentyseventeen-front-page #primary .entry-content blockquote.alignright,
 	.archive:not(.has-sidebar) .entry-content blockquote.alignright,
 	.page-two-column #primary .entry-content blockquote.alignright {

--- a/style.css
+++ b/style.css
@@ -3031,7 +3031,7 @@ article.panel-placeholder {
 
 	/* blog and archive */
 
-	.blog:not(.has-sidebar):not(.home) .entry-content blockquote.alignleft,
+	.blog:not(.has-sidebar) .entry-content blockquote.alignleft,
 	.twentyseventeen-front-page .entry-content blockquote.alignleft,
 	.archive:not(.has-sidebar) .entry-content blockquote.alignleft,
 	.page-two-column .entry-content blockquote.alignleft {
@@ -3039,7 +3039,7 @@ article.panel-placeholder {
 		width: 62%;
 	}
 
-	.blog:not(.has-sidebar):not(.home) .entry-content blockquote.alignright,
+	.blog:not(.has-sidebar) .entry-content blockquote.alignright,
 	.twentyseventeen-front-page .entry-content blockquote.alignright,
 	.archive:not(.has-sidebar) .entry-content blockquote.alignright,
 	.page-two-column .entry-content blockquote.alignright {


### PR DESCRIPTION
When I fixed #292, I didn't update the blockquotes that are aligned left and right. When there is no sidebar, the one on the left should sit quite far left, outside of the flow of the content, but that was not happening:

![Image](https://cldup.com/dMUz8Haulu-3000x3000.png)

This update should pull it further left where it belongs, like this:

![Image](https://cldup.com/aG5_kkcK9T.thumb.jpg)

There's also an update for RTL styles.

This affects the blog index when it's set as the front page of the site, and doesn't have a sidebar.
