### PR TITLE
Move IE8-specific image sizing style to ie8.css

### DIFF
--- a/assets/css/ie8.css
+++ b/assets/css/ie8.css
@@ -95,6 +95,10 @@ time.published {
 	z-index: -1;
 }
 
+img {
+	width: inherit;  /* Make images fill their parent's space. */
+}
+
 /* Fixes linked images */
 .entry-content a img,
 .widget a img {

--- a/style.css
+++ b/style.css
@@ -2158,7 +2158,6 @@ h2.widget-title {
 
 img {
 	height: auto; /* Make sure images are scaled correctly. */
-	width: inherit;  /* Make images fill their parent's space. Solves IE8. */
 	max-width: 100%; /* Adhere to container width. */
 }
 


### PR DESCRIPTION
Related to issue #305.

Moved IE8 specific `img` style from style.css to ie8.css. It seemed to be causing some odd scaling issues in other browsers.
