### PR TITLE
Update sticky icon to appear on all post formats, only on blog index

### DIFF
--- a/components/post/content-audio.php
+++ b/components/post/content-audio.php
@@ -12,6 +12,11 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+	<?php
+		if ( is_sticky() && is_home() ) :
+			echo twentyseventeen_get_svg( array( 'icon' => 'pinned' ) );
+		endif;
+	?>
 	<header class="entry-header">
 		<?php
 			if ( 'post' === get_post_type() ) :

--- a/components/post/content-gallery.php
+++ b/components/post/content-gallery.php
@@ -12,6 +12,11 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+	<?php
+		if ( is_sticky() && is_home() ) :
+			echo twentyseventeen_get_svg( array( 'icon' => 'pinned' ) );
+		endif;
+	?>
 	<header class="entry-header">
 		<?php
 			if ( 'post' === get_post_type() ) :

--- a/components/post/content-image.php
+++ b/components/post/content-image.php
@@ -12,6 +12,11 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+	<?php
+		if ( is_sticky() && is_home() ) :
+			echo twentyseventeen_get_svg( array( 'icon' => 'pinned' ) );
+		endif;
+	?>
 	<header class="entry-header">
 		<?php
 			if ( 'post' === get_post_type() ) :

--- a/components/post/content-video.php
+++ b/components/post/content-video.php
@@ -12,6 +12,11 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+	<?php
+		if ( is_sticky() && is_home() ) :
+			echo twentyseventeen_get_svg( array( 'icon' => 'pinned' ) );
+		endif;
+	?>
 	<header class="entry-header">
 		<?php
 			if ( 'post' === get_post_type() ) :

--- a/components/post/content.php
+++ b/components/post/content.php
@@ -14,7 +14,7 @@
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<?php
-		if ( is_sticky() ) :
+		if ( is_sticky() && is_home() ) :
 			echo twentyseventeen_get_svg( array( 'icon' => 'pinned' ) );
 		endif;
 	?>

--- a/style.css
+++ b/style.css
@@ -1372,7 +1372,11 @@ body {
 	position: relative;
 }
 
-.sticky .icon {
+.icon-pinned {
+	display: none;
+}
+
+.sticky .icon-pinned {
 	display: block;
 	height: 20px;
 	left: -1em;


### PR DESCRIPTION
The sticky icon was only appearing on post formats using the content.php file - so it was not appearing on sticky audio, video, gallery or image posts:

![Image](https://cldup.com/LI_k0Hk491-3000x3000.png)

When it was displaying, it was also appearing on single posts, and whenever the post appeared, not just in its stuck position. Here's an example of the sticky post:

![Image](https://cldup.com/LcW_chV2EL.thumb.jpg)

This PR makes sure the icon only appears on the blog index, when the post is 'stuck' (and not in the regular flow), and for all post formats. 
