### PR TITLE
<q> tag css

### DIFF
--- a/style.css
+++ b/style.css
@@ -540,7 +540,7 @@ blockquote {
 }
 
 q {
-	quotes: "“" "”";
+	quotes: "“" "”" "‘" "’";
 }
 
 blockquote:before,

--- a/style.css
+++ b/style.css
@@ -535,14 +535,12 @@ big {
 	font-size: 125%;
 }
 
-blockquote, q {
+blockquote {
 	quotes: "" "";
 }
 
 blockquote:before,
-blockquote:after,
-q:before,
-q:after {
+blockquote:after {
 	content: "";
 }
 

--- a/style.css
+++ b/style.css
@@ -538,7 +538,9 @@ big {
 blockquote {
 	quotes: "" "";
 }
-
+q {
+	quotes: "“" "”";
+}
 blockquote:before,
 blockquote:after {
 	content: "";

--- a/style.css
+++ b/style.css
@@ -538,9 +538,11 @@ big {
 blockquote {
 	quotes: "" "";
 }
+
 q {
 	quotes: "“" "”";
 }
+
 blockquote:before,
 blockquote:after {
 	content: "";


### PR DESCRIPTION
Fixes #202 
Adds quotes around the text (in case it's wrapped in `<q></q>`)
