### PR TITLE
Content variable consistency

### DIFF
--- a/components/post/content-audio.php
+++ b/components/post/content-audio.php
@@ -31,7 +31,7 @@
 			}
 		?>
 	</header><!-- .entry-header -->
-	
+
 	<?php
 		$content = apply_filters( 'the_content', get_the_content() );
 		$audio = get_media_embedded_in_content( $content, array( 'audio' ) );

--- a/components/post/content-audio.php
+++ b/components/post/content-audio.php
@@ -31,6 +31,11 @@
 			}
 		?>
 	</header><!-- .entry-header -->
+	
+	<?php
+		$content = apply_filters( 'the_content', get_the_content() );
+		$audio = get_media_embedded_in_content( $content, array( 'audio' ) );
+	?>
 
 	<?php if ( '' !== get_the_post_thumbnail() && ! is_single() ) : ?>
 		<div class="post-thumbnail">
@@ -45,9 +50,6 @@
 		<?php if ( ! is_single() ) :
 
 			// If not a single post, highlight the audio file
-			$content = apply_filters( 'the_content', get_the_content() );
-			$audio = get_media_embedded_in_content( $content, array( 'audio' ) );
-
 			if ( ! empty( $audio ) ) :
 				foreach ( $audio as $audio_html ) {
 					echo '<div class="entry-audio">';

--- a/components/post/content-gallery.php
+++ b/components/post/content-gallery.php
@@ -45,8 +45,6 @@
 		<?php if ( ! is_single() ) :
 
 			// If not a single post, highlight the gallery
-			$content = apply_filters( 'the_content', get_the_content() );
-
 			if ( get_post_gallery() ) :
 				echo '<div class="entry-gallery">';
 					echo get_post_gallery();


### PR DESCRIPTION
Resolves #301 
- removes `$content` from `content-gallery.php` (which is never used anyway)
- defines `$content` and `$audio` earlier in `content-audio.php` to make it consistent with `content-video.php`
