### PR TITLE
Consolidate twentyseventeen_edit_post_link and twentyseventeen_edit_link

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -50,25 +50,6 @@ function twentyseventeen_time_link() {
 endif;
 
 
-if ( ! function_exists( 'twentyseventeen_edit_post_link' ) ) :
-/**
- * Prints the post's edit link.
- */
-function twentyseventeen_edit_post_link() {
-	// Display 'edit' link.
-	edit_post_link(
-		sprintf(
-			/* translators: %s: Name of current post */
-			__( 'Edit %s', 'twentyseventeen' ),
-			the_title( '<span class="screen-reader-text">"', '"</span>', false )
-		),
-		'<span class="edit-link">',
-		'</span>'
-	);
-}
-endif;
-
-
 if ( ! function_exists( 'twentyseventeen_entry_footer' ) ) :
 /**
  * Prints HTML with meta information for the categories, tags and comments.
@@ -97,7 +78,7 @@ function twentyseventeen_entry_footer() {
 		echo '</span>';
 	}
 
-	twentyseventeen_edit_post_link();
+	twentyseventeen_edit_link();
 }
 endif;
 
@@ -109,10 +90,8 @@ endif;
  * (post or page?) so that users understand a bit more where they are in terms
  * of the template hierarchy and their content. Helpful when/if the single-page
  * layout with multiple posts/pages shown gets confusing.
- *
- * @param int $id The post ID.
  */
-function twentyseventeen_edit_link( $id ) {
+function twentyseventeen_edit_link() {
 
 	$link = edit_post_link(
 		sprintf(


### PR DESCRIPTION
`twentyseventeen_edit_post_link` and `twentyseventeen_edit_link` are duplicate functions. This PR removes `twentyseventeen_edit_post_link`
