### PR TITLE
Change the content width in the function, not the template

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -18,11 +18,6 @@ if ( 'posts' === get_option( 'show_on_front' ) ) :
 
 else :
 
-// Access global variable directly to set content_width global.
-if ( isset( $GLOBALS['content_width'] ) ) {
-	$GLOBALS['content_width'] = 1120;
-}
-
 get_header(); ?>
 
 

--- a/functions.php
+++ b/functions.php
@@ -100,7 +100,14 @@ add_action( 'after_setup_theme', 'twentyseventeen_setup' );
  * @global int $content_width
  */
 function twentyseventeen_content_width() {
-	$GLOBALS['content_width'] = apply_filters( 'twentyseventeen_content_width', 700 );
+
+	$content_width = 700;
+
+	if ( twentyseventeen_is_frontpage() ) {
+		$content_width = 1120;
+	}
+
+	$GLOBALS['content_width'] = apply_filters( 'twentyseventeen_content_width', $content_width );
 }
 add_action( 'after_setup_theme', 'twentyseventeen_content_width', 0 );
 


### PR DESCRIPTION
By defining the content width in the function it can be changed or overritten. To be able to change the content width in the template the whole template would need to be copied to the child theme.

I was not sure how I could test that it works. Please test it before mergeing.
