### PR TITLE
Use `DATE_W3C` in date functions to get correct time zone data.

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -38,9 +38,9 @@ function twentyseventeen_time_link() {
 	}
 
 	$time_string = sprintf( $time_string,
-		get_the_date( 'c' ),
+		get_the_date( DATE_W3C ),
 		get_the_date(),
-		get_the_modified_date( 'c' ),
+		get_the_modified_date( DATE_W3C ),
 		get_the_modified_date()
 	);
 


### PR DESCRIPTION
- This avoids a bug in Core. See: https://core.trac.wordpress.org/ticket/20973

Fixes #127.
