### PR TITLE
Use new functions available for theme developers in 4.7.

### DIFF
--- a/components/header/site-branding.php
+++ b/components/header/site-branding.php
@@ -12,7 +12,7 @@
 <div class="site-branding">
 	<div class="wrap">
 
-		<?php twentyseventeen_the_custom_logo(); ?>
+		<?php the_custom_logo(); ?>
 
 		<?php if ( is_front_page() ) : ?>
 			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>

--- a/functions.php
+++ b/functions.php
@@ -13,337 +13,307 @@
  * Twenty Seventeen only works in WordPress 4.7 or later.
  */
 if ( version_compare( $GLOBALS['wp_version'], '4.7-alpha', '<' ) ) {
-
 	require get_template_directory() . '/inc/back-compat.php';
-
-} else {
-
-	/**
-	 * Twenty Seventeen functions and definitions
-	 *
-	 * @link https://developer.wordpress.org/themes/basics/theme-functions/
-	 *
-	 * @package WordPress
-	 * @subpackage Twenty_Seventeen
-	 * @since 1.0
-	 */
-
-	if ( ! function_exists( 'twentyseventeen_setup' ) ) :
-	/**
-	 * Sets up theme defaults and registers support for various WordPress features.
-	 *
-	 * Note that this function is hooked into the after_setup_theme hook, which
-	 * runs before the init hook. The init hook is too late for some features, such
-	 * as indicating support for post thumbnails.
-	 */
-	function twentyseventeen_setup() {
-		/*
-		 * Make theme available for translation.
-		 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentyseventeen
-		 * If you're building a theme based on Twenty Seventeen, use a find and replace
-		 * to change 'twentyseventeen' to the name of your theme in all the template files.
-		 */
-		load_theme_textdomain( 'twentyseventeen' );
-
-		// Add default posts and comments RSS feed links to head.
-		add_theme_support( 'automatic-feed-links' );
-
-		/*
-		 * Let WordPress manage the document title.
-		 * By adding theme support, we declare that this theme does not use a
-		 * hard-coded <title> tag in the document head, and expect WordPress to
-		 * provide it for us.
-		 */
-		add_theme_support( 'title-tag' );
-
-		/*
-		 * Enable support for Post Thumbnails on posts and pages.
-		 *
-		 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
-		 */
-		add_theme_support( 'post-thumbnails' );
-
-		add_image_size( 'twentyseventeen-featured-image', 2000, 1200, true );
-
-		add_image_size( 'twentyseventeen-thumbnail-avatar', 100, 100, true );
-
-		// This theme uses wp_nav_menu() in two locations.
-		register_nav_menus( array(
-			'top'    => __( 'Top', 'twentyseventeen' ),
-			'social' => __( 'Social Links Menu', 'twentyseventeen' ),
-		) );
-
-		/*
-		 * Switch default core markup for search form, comment form, and comments
-		 * to output valid HTML5.
-		 */
-		add_theme_support( 'html5', array(
-			'comment-form',
-			'comment-list',
-			'gallery',
-			'caption',
-		) );
-
-		/*
-		 * Enable support for Post Formats.
-		 *
-		 * See: https://codex.wordpress.org/Post_Formats
-		 */
-		add_theme_support( 'post-formats', array(
-			'aside',
-			'image',
-			'video',
-			'quote',
-			'link',
-			'gallery',
-			'audio',
-		) );
-
-		// Add theme support for Custom Logo.
-		add_theme_support( 'custom-logo', array(
-			'width'       => 1000,
-			'height'      => 1000,
-			'flex-width'  => true,
-			'flex-height' => true,
-		) );
-	}
-	endif;
-	add_action( 'after_setup_theme', 'twentyseventeen_setup' );
-
-
-	/**
-	 * Set the content width in pixels, based on the theme's design and stylesheet.
-	 *
-	 * Priority 0 to make it available to lower priority callbacks.
-	 *
-	 * @global int $content_width
-	 */
-	function twentyseventeen_content_width() {
-		$GLOBALS['content_width'] = apply_filters( 'twentyseventeen_content_width', 700 );
-	}
-	add_action( 'after_setup_theme', 'twentyseventeen_content_width', 0 );
-
-
-	/**
-	 * Register custom fonts
-	 */
-	function twentyseventeen_fonts_url() {
-		$fonts_url = '';
-
-		/**
-		 * Translators: If there are characters in your language that are not
-		 * supported by Libre Frankin, translate this to 'off'. Do not translate
-		 * into your own language.
-		 */
-		$libre_franklin = _x( 'on', 'libre_franklin font: on or off', 'twentyseventeen' );
-
-		if ( 'off' !== $libre_franklin ) {
-			$font_families = array();
-
-			$font_families[] = 'Libre Franklin:300,300i,400,400i,600,600i,800,800i';
-
-			$query_args = array(
-				'family' => urlencode( implode( '|', $font_families ) ),
-				'subset' => urlencode( 'latin,latin-ext' ),
-			);
-
-			$fonts_url = add_query_arg( $query_args, 'https://fonts.googleapis.com/css' );
-		}
-
-		return esc_url_raw( $fonts_url );
-	}
-
-	/**
-	 * Register widget area.
-	 *
-	 * @link https://developer.wordpress.org/themes/functionality/sidebars/#registering-a-sidebar
-	 */
-	function twentyseventeen_widgets_init() {
-		register_sidebar( array(
-			'name'          => __( 'Sidebar', 'twentyseventeen' ),
-			'id'            => 'sidebar-1',
-			'description'   => '',
-			'before_widget' => '<section id="%1$s" class="widget %2$s">',
-			'after_widget'  => '</section>',
-			'before_title'  => '<h2 class="widget-title">',
-			'after_title'   => '</h2>',
-		) );
-
-		register_sidebar( array(
-			'name'          => __( 'Footer 1', 'twentyseventeen' ),
-			'id'            => 'sidebar-2',
-			'description'   => '',
-			'before_widget' => '<section id="%1$s" class="widget %2$s">',
-			'after_widget'  => '</section>',
-			'before_title'  => '<h2 class="widget-title">',
-			'after_title'   => '</h2>',
-		) );
-
-		register_sidebar( array(
-			'name'          => __( 'Footer 2', 'twentyseventeen' ),
-			'id'            => 'sidebar-3',
-			'description'   => '',
-			'before_widget' => '<section id="%1$s" class="widget %2$s">',
-			'after_widget'  => '</section>',
-			'before_title'  => '<h2 class="widget-title">',
-			'after_title'   => '</h2>',
-		) );
-	}
-	add_action( 'widgets_init', 'twentyseventeen_widgets_init' );
-
-
-	/**
-	 * Output Custom Logo.
-	 */
-	function twentyseventeen_the_custom_logo() {
-		if ( function_exists( 'the_custom_logo' ) ) {
-			the_custom_logo();
-		}
-	}
-
-
-	if ( ! function_exists( 'twentyseventeen_excerpt_continue_reading' ) ) {
-	/**
-	 * Replaces the excerpt "more" text by a link
-	 */
-	function twentyseventeen_excerpt_continue_reading() {
-		return ' &hellip; <p class="link-more"><a href="' . esc_url( get_permalink() ) . '">' . sprintf( __( 'Continue reading %s', 'twentyseventeen' ), the_title( '<span class="screen-reader-text">"', '"</span>', false ) ) . '</a></p>';
-	}
-	}
-	add_filter( 'excerpt_more', 'twentyseventeen_excerpt_continue_reading' );
-
-
-	/**
-	 * Handles JavaScript detection.
-	 *
-	 * Adds a `js` class to the root `<html>` element when JavaScript is detected.
-	 *
-	 * @since Twenty Seventeen 1.0
-	 */
-	function twentyseventeen_javascript_detection() {
-		echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>\n";
-	}
-	add_action( 'wp_head', 'twentyseventeen_javascript_detection', 0 );
-
-	/**
-	 * Enqueue scripts and styles.
-	 */
-	function twentyseventeen_scripts() {
-		// Add custom fonts, used in the main stylesheet.
-		wp_enqueue_style( 'twentyseventeen-fonts', twentyseventeen_fonts_url(), array(), null );
-
-		// Theme stylesheet.
-		wp_enqueue_style( 'twentyseventeen-style', get_stylesheet_uri() );
-
-		// Load the dark colorscheme.
-		if ( 'dark' === get_theme_mod( 'colorscheme', 'light' ) || is_customize_preview() ) {
-			wp_enqueue_style( 'twentyseventeen-colors-dark', get_theme_file_uri( '/assets/css/colors-dark.css' ), array( 'twentyseventeen-style' ), '20161006' );
-		}
-
-		// Load the Internet Explorer 8 specific stylesheet.
-		wp_enqueue_style( 'twentyseventeen-ie8', get_theme_file_uri( '/assets/css/ie8.css' ), array( 'twentyseventeen-style' ), '20160928' );
-		wp_style_add_data( 'twentyseventeen-ie8', 'conditional', 'lt IE 9' );
-
-		// Load the html5 shiv.
-		wp_enqueue_script( 'html5', get_theme_file_uri( '/assets/js/html5.js' ), array(), '3.7.3' );
-		wp_script_add_data( 'html5', 'conditional', 'lt IE 9' );
-
-		wp_enqueue_script( 'twentyseventeen-skip-link-focus-fix', get_theme_file_uri( '/assets/js/skip-link-focus-fix.js' ), array(), '20151215', true );
-
-		wp_enqueue_script( 'twentyseventeen-navigation', get_theme_file_uri( '/assets/js/navigation.js' ), array(), '20151215', true );
-
-		wp_localize_script( 'twentyseventeen-navigation', 'twentyseventeenScreenReaderText', array(
-			'expand'   => __( 'Expand child menu', 'twentyseventeen' ),
-			'collapse' => __( 'Collapse child menu', 'twentyseventeen' ),
-			'icon'     => twentyseventeen_get_svg( array( 'icon' => 'expand' ) ),
-		) );
-
-		wp_enqueue_script( 'twentyseventeen-global', get_theme_file_uri( '/assets/js/global.js' ), array( 'jquery' ), '20151215', true );
-
-		if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
-			wp_enqueue_script( 'comment-reply' );
-		}
-
-		// Scroll effects (only loaded on front page).
-		if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) {
-			wp_enqueue_script( 'jquery-scrollto', get_theme_file_uri( '/assets/js/jquery.scrollTo.js' ), array( 'jquery' ), '20151030', true );
-		}
-
-	}
-	add_action( 'wp_enqueue_scripts', 'twentyseventeen_scripts' );
-
-
-	/**
-	 * Add custom image sizes attribute to enhance responsive image functionality
-	 * for content images
-	 *
-	 * @since Twenty Seventeen 1.0
-	 *
-	 * @param string $sizes A source size value for use in a 'sizes' attribute.
-	 * @param array  $size  Image size. Accepts an array of width and height
-	 *                      values in pixels (in that order).
-	 * @return string A source size value for use in a content image 'sizes' attribute.
-	 */
-	function twentyseventeen_content_image_sizes_attr( $sizes, $size ) {
-		$width = $size[0];
-
-		740 <= $width && $sizes = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, 740px';
-
-		if ( is_active_sidebar( 'sidebar-1' ) || is_archive() || is_search() || is_home() || is_page() ) {
-			if ( ! ( is_page() && 'one-column' === get_theme_mod( 'page_options' ) ) ) {
-				767 <= $width && $sizes = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
-			}
-		}
-
-		return $sizes;
-	}
-	add_filter( 'wp_calculate_image_sizes', 'twentyseventeen_content_image_sizes_attr', 10 , 2 );
-
-	/**
-	 * Add custom image sizes attribute to enhance responsive image functionality
-	 * for post thumbnails
-	 *
-	 * @since Twenty Seventeen 1.0
-	 *
-	 * @param array $attr Attributes for the image markup.
-	 * @param int   $attachment Image attachment ID.
-	 * @param array $size Registered image size or flat array of height and width dimensions.
-	 * @return string A source size value for use in a post thumbnail 'sizes' attribute.
-	 */
-	function twentyseventeen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
-		if ( is_archive() || is_search() || is_home() ) {
-			$attr['sizes'] = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
-		} else {
-			$attr['sizes'] = '100vw';
-		}
-		return $attr;
-	}
-	add_filter( 'wp_get_attachment_image_attributes', 'twentyseventeen_post_thumbnail_sizes_attr', 10 , 3 );
-
-
-	/**
-	 * Implement the Custom Header feature.
-	 */
-	require get_parent_theme_file_path( '/inc/custom-header.php' );
-
-	/**
-	 * Custom template tags for this theme.
-	 */
-	require get_parent_theme_file_path( '/inc/template-tags.php' );
-
-	/**
-	 * Custom functions that act independently of the theme templates.
-	 */
-	require get_parent_theme_file_path( '/inc/extras.php' );
-
-	/**
-	 * Customizer additions.
-	 */
-	require get_parent_theme_file_path( '/inc/customizer.php' );
-
-	/**
-	 * SVG icons functions and filters.
-	 */
-	require get_parent_theme_file_path( '/inc/functions-icons.php' );
-
+	return;
 }
+
+if ( ! function_exists( 'twentyseventeen_setup' ) ) :
+/**
+ * Sets up theme defaults and registers support for various WordPress features.
+ *
+ * Note that this function is hooked into the after_setup_theme hook, which
+ * runs before the init hook. The init hook is too late for some features, such
+ * as indicating support for post thumbnails.
+ */
+function twentyseventeen_setup() {
+	/*
+	 * Make theme available for translation.
+	 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentyseventeen
+	 * If you're building a theme based on Twenty Seventeen, use a find and replace
+	 * to change 'twentyseventeen' to the name of your theme in all the template files.
+	 */
+	load_theme_textdomain( 'twentyseventeen' );
+
+	// Add default posts and comments RSS feed links to head.
+	add_theme_support( 'automatic-feed-links' );
+
+	/*
+	 * Let WordPress manage the document title.
+	 * By adding theme support, we declare that this theme does not use a
+	 * hard-coded <title> tag in the document head, and expect WordPress to
+	 * provide it for us.
+	 */
+	add_theme_support( 'title-tag' );
+
+	/*
+	 * Enable support for Post Thumbnails on posts and pages.
+	 *
+	 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
+	 */
+	add_theme_support( 'post-thumbnails' );
+
+	add_image_size( 'twentyseventeen-featured-image', 2000, 1200, true );
+
+	add_image_size( 'twentyseventeen-thumbnail-avatar', 100, 100, true );
+
+	// This theme uses wp_nav_menu() in two locations.
+	register_nav_menus( array(
+		'top'    => __( 'Top', 'twentyseventeen' ),
+		'social' => __( 'Social Links Menu', 'twentyseventeen' ),
+	) );
+
+	/*
+	 * Switch default core markup for search form, comment form, and comments
+	 * to output valid HTML5.
+	 */
+	add_theme_support( 'html5', array(
+		'comment-form',
+		'comment-list',
+		'gallery',
+		'caption',
+	) );
+
+	/*
+	 * Enable support for Post Formats.
+	 *
+	 * See: https://codex.wordpress.org/Post_Formats
+	 */
+	add_theme_support( 'post-formats', array(
+		'aside',
+		'image',
+		'video',
+		'quote',
+		'link',
+		'gallery',
+		'audio',
+	) );
+
+	// Add theme support for Custom Logo.
+	add_theme_support( 'custom-logo', array(
+		'width'       => 1000,
+		'height'      => 1000,
+		'flex-width'  => true,
+		'flex-height' => true,
+	) );
+}
+endif;
+add_action( 'after_setup_theme', 'twentyseventeen_setup' );
+
+/**
+ * Set the content width in pixels, based on the theme's design and stylesheet.
+ *
+ * Priority 0 to make it available to lower priority callbacks.
+ *
+ * @global int $content_width
+ */
+function twentyseventeen_content_width() {
+	$GLOBALS['content_width'] = apply_filters( 'twentyseventeen_content_width', 700 );
+}
+add_action( 'after_setup_theme', 'twentyseventeen_content_width', 0 );
+
+/**
+ * Register custom fonts
+ */
+function twentyseventeen_fonts_url() {
+	$fonts_url = '';
+
+	/**
+	 * Translators: If there are characters in your language that are not
+	 * supported by Libre Frankin, translate this to 'off'. Do not translate
+	 * into your own language.
+	 */
+	$libre_franklin = _x( 'on', 'libre_franklin font: on or off', 'twentyseventeen' );
+
+	if ( 'off' !== $libre_franklin ) {
+		$font_families = array();
+
+		$font_families[] = 'Libre Franklin:300,300i,400,400i,600,600i,800,800i';
+
+		$query_args = array(
+			'family' => urlencode( implode( '|', $font_families ) ),
+			'subset' => urlencode( 'latin,latin-ext' ),
+		);
+
+		$fonts_url = add_query_arg( $query_args, 'https://fonts.googleapis.com/css' );
+	}
+
+	return esc_url_raw( $fonts_url );
+}
+
+/**
+ * Register widget area.
+ *
+ * @link https://developer.wordpress.org/themes/functionality/sidebars/#registering-a-sidebar
+ */
+function twentyseventeen_widgets_init() {
+	register_sidebar( array(
+		'name'          => __( 'Sidebar', 'twentyseventeen' ),
+		'id'            => 'sidebar-1',
+		'description'   => '',
+		'before_widget' => '<section id="%1$s" class="widget %2$s">',
+		'after_widget'  => '</section>',
+		'before_title'  => '<h2 class="widget-title">',
+		'after_title'   => '</h2>',
+	) );
+
+	register_sidebar( array(
+		'name'          => __( 'Footer 1', 'twentyseventeen' ),
+		'id'            => 'sidebar-2',
+		'description'   => '',
+		'before_widget' => '<section id="%1$s" class="widget %2$s">',
+		'after_widget'  => '</section>',
+		'before_title'  => '<h2 class="widget-title">',
+		'after_title'   => '</h2>',
+	) );
+
+	register_sidebar( array(
+		'name'          => __( 'Footer 2', 'twentyseventeen' ),
+		'id'            => 'sidebar-3',
+		'description'   => '',
+		'before_widget' => '<section id="%1$s" class="widget %2$s">',
+		'after_widget'  => '</section>',
+		'before_title'  => '<h2 class="widget-title">',
+		'after_title'   => '</h2>',
+	) );
+}
+add_action( 'widgets_init', 'twentyseventeen_widgets_init' );
+
+if ( ! function_exists( 'twentyseventeen_excerpt_continue_reading' ) ) {
+/**
+ * Replaces the excerpt "more" text by a link
+ */
+function twentyseventeen_excerpt_continue_reading() {
+	return ' &hellip; <p class="link-more"><a href="' . esc_url( get_permalink() ) . '">' . sprintf( __( 'Continue reading %s', 'twentyseventeen' ), the_title( '<span class="screen-reader-text">"', '"</span>', false ) ) . '</a></p>';
+}
+}
+add_filter( 'excerpt_more', 'twentyseventeen_excerpt_continue_reading' );
+
+/**
+ * Handles JavaScript detection.
+ *
+ * Adds a `js` class to the root `<html>` element when JavaScript is detected.
+ *
+ * @since Twenty Seventeen 1.0
+ */
+function twentyseventeen_javascript_detection() {
+	echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>\n";
+}
+add_action( 'wp_head', 'twentyseventeen_javascript_detection', 0 );
+
+/**
+ * Enqueue scripts and styles.
+ */
+function twentyseventeen_scripts() {
+	// Add custom fonts, used in the main stylesheet.
+	wp_enqueue_style( 'twentyseventeen-fonts', twentyseventeen_fonts_url(), array(), null );
+
+	// Theme stylesheet.
+	wp_enqueue_style( 'twentyseventeen-style', get_stylesheet_uri() );
+
+	// Load the dark colorscheme.
+	if ( 'dark' === get_theme_mod( 'colorscheme', 'light' ) || is_customize_preview() ) {
+		wp_enqueue_style( 'twentyseventeen-colors-dark', get_theme_file_uri( '/assets/css/colors-dark.css' ), array( 'twentyseventeen-style' ), '20161006' );
+	}
+
+	// Load the Internet Explorer 8 specific stylesheet.
+	wp_enqueue_style( 'twentyseventeen-ie8', get_theme_file_uri( '/assets/css/ie8.css' ), array( 'twentyseventeen-style' ), '20160928' );
+	wp_style_add_data( 'twentyseventeen-ie8', 'conditional', 'lt IE 9' );
+
+	// Load the html5 shiv.
+	wp_enqueue_script( 'html5', get_theme_file_uri( '/assets/js/html5.js' ), array(), '3.7.3' );
+	wp_script_add_data( 'html5', 'conditional', 'lt IE 9' );
+
+	wp_enqueue_script( 'twentyseventeen-skip-link-focus-fix', get_theme_file_uri( '/assets/js/skip-link-focus-fix.js' ), array(), '20151215', true );
+
+	wp_enqueue_script( 'twentyseventeen-navigation', get_theme_file_uri( '/assets/js/navigation.js' ), array(), '20151215', true );
+
+	wp_localize_script( 'twentyseventeen-navigation', 'twentyseventeenScreenReaderText', array(
+		'expand'   => __( 'Expand child menu', 'twentyseventeen' ),
+		'collapse' => __( 'Collapse child menu', 'twentyseventeen' ),
+		'icon'     => twentyseventeen_get_svg( array( 'icon' => 'expand' ) ),
+	) );
+
+	wp_enqueue_script( 'twentyseventeen-global', get_theme_file_uri( '/assets/js/global.js' ), array( 'jquery' ), '20151215', true );
+
+	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
+		wp_enqueue_script( 'comment-reply' );
+	}
+
+	// Scroll effects (only loaded on front page).
+	if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) {
+		wp_enqueue_script( 'jquery-scrollto', get_theme_file_uri( '/assets/js/jquery.scrollTo.js' ), array( 'jquery' ), '20151030', true );
+	}
+}
+add_action( 'wp_enqueue_scripts', 'twentyseventeen_scripts' );
+
+/**
+ * Add custom image sizes attribute to enhance responsive image functionality
+ * for content images
+ *
+ * @since Twenty Seventeen 1.0
+ *
+ * @param string $sizes A source size value for use in a 'sizes' attribute.
+ * @param array  $size  Image size. Accepts an array of width and height
+ *                      values in pixels (in that order).
+ * @return string A source size value for use in a content image 'sizes' attribute.
+ */
+function twentyseventeen_content_image_sizes_attr( $sizes, $size ) {
+	$width = $size[0];
+
+	740 <= $width && $sizes = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, 740px';
+
+	if ( is_active_sidebar( 'sidebar-1' ) || is_archive() || is_search() || is_home() || is_page() ) {
+		if ( ! ( is_page() && 'one-column' === get_theme_mod( 'page_options' ) ) ) {
+			767 <= $width && $sizes = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
+		}
+	}
+
+	return $sizes;
+}
+add_filter( 'wp_calculate_image_sizes', 'twentyseventeen_content_image_sizes_attr', 10 , 2 );
+
+/**
+ * Add custom image sizes attribute to enhance responsive image functionality
+ * for post thumbnails
+ *
+ * @since Twenty Seventeen 1.0
+ *
+ * @param array $attr Attributes for the image markup.
+ * @param int   $attachment Image attachment ID.
+ * @param array $size Registered image size or flat array of height and width dimensions.
+ * @return string A source size value for use in a post thumbnail 'sizes' attribute.
+ */
+function twentyseventeen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
+	if ( is_archive() || is_search() || is_home() ) {
+		$attr['sizes'] = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
+	} else {
+		$attr['sizes'] = '100vw';
+	}
+	return $attr;
+}
+add_filter( 'wp_get_attachment_image_attributes', 'twentyseventeen_post_thumbnail_sizes_attr', 10 , 3 );
+
+/**
+ * Implement the Custom Header feature.
+ */
+require get_parent_theme_file_path( '/inc/custom-header.php' );
+
+/**
+ * Custom template tags for this theme.
+ */
+require get_parent_theme_file_path( '/inc/template-tags.php' );
+
+/**
+ * Custom functions that act independently of the theme templates.
+ */
+require get_parent_theme_file_path( '/inc/extras.php' );
+
+/**
+ * Customizer additions.
+ */
+require get_parent_theme_file_path( '/inc/customizer.php' );
+
+/**
+ * SVG icons functions and filters.
+ */
+require get_parent_theme_file_path( '/inc/functions-icons.php' );

--- a/functions.php
+++ b/functions.php
@@ -17,6 +17,7 @@ if ( version_compare( $GLOBALS['wp_version'], '4.7-alpha', '<' ) ) {
 	require get_template_directory() . '/inc/back-compat.php';
 
 } else {
+
 	/**
 	 * Twenty Seventeen functions and definitions
 	 *

--- a/functions.php
+++ b/functions.php
@@ -9,320 +9,340 @@
  * @since 1.0
  */
 
-if ( ! function_exists( 'twentyseventeen_setup' ) ) :
 /**
- * Sets up theme defaults and registers support for various WordPress features.
- *
- * Note that this function is hooked into the after_setup_theme hook, which
- * runs before the init hook. The init hook is too late for some features, such
- * as indicating support for post thumbnails.
+ * Twenty Seventeen only works in WordPress 4.7 or later.
  */
-function twentyseventeen_setup() {
-	/*
-	 * Make theme available for translation.
-	 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentyseventeen
-	 * If you're building a theme based on Twenty Seventeen, use a find and replace
-	 * to change 'twentyseventeen' to the name of your theme in all the template files.
-	 */
-	load_theme_textdomain( 'twentyseventeen' );
+if ( version_compare( $GLOBALS['wp_version'], '4.7-alpha', '<' ) ) {
 
-	// Add default posts and comments RSS feed links to head.
-	add_theme_support( 'automatic-feed-links' );
+	require get_template_directory() . '/inc/back-compat.php';
 
-	/*
-	 * Let WordPress manage the document title.
-	 * By adding theme support, we declare that this theme does not use a
-	 * hard-coded <title> tag in the document head, and expect WordPress to
-	 * provide it for us.
-	 */
-	add_theme_support( 'title-tag' );
-
-	/*
-	 * Enable support for Post Thumbnails on posts and pages.
+} else {
+	/**
+	 * Twenty Seventeen functions and definitions
 	 *
-	 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
-	 */
-	add_theme_support( 'post-thumbnails' );
-
-	add_image_size( 'twentyseventeen-featured-image', 2000, 1200, true );
-
-	add_image_size( 'twentyseventeen-thumbnail-avatar', 100, 100, true );
-
-	// This theme uses wp_nav_menu() in two locations.
-	register_nav_menus( array(
-		'top'    => __( 'Top', 'twentyseventeen' ),
-		'social' => __( 'Social Links Menu', 'twentyseventeen' ),
-	) );
-
-	/*
-	 * Switch default core markup for search form, comment form, and comments
-	 * to output valid HTML5.
-	 */
-	add_theme_support( 'html5', array(
-		'comment-form',
-		'comment-list',
-		'gallery',
-		'caption',
-	) );
-
-	/*
-	 * Enable support for Post Formats.
+	 * @link https://developer.wordpress.org/themes/basics/theme-functions/
 	 *
-	 * See: https://codex.wordpress.org/Post_Formats
+	 * @package WordPress
+	 * @subpackage Twenty_Seventeen
+	 * @since 1.0
 	 */
-	add_theme_support( 'post-formats', array(
-		'aside',
-		'image',
-		'video',
-		'quote',
-		'link',
-		'gallery',
-		'audio',
-	) );
 
-	// Add theme support for Custom Logo.
-	add_theme_support( 'custom-logo', array(
-		'width'       => 1000,
-		'height'      => 1000,
-		'flex-width'  => true,
-		'flex-height' => true,
-	) );
-}
-endif;
-add_action( 'after_setup_theme', 'twentyseventeen_setup' );
+	if ( ! function_exists( 'twentyseventeen_setup' ) ) :
+	/**
+	 * Sets up theme defaults and registers support for various WordPress features.
+	 *
+	 * Note that this function is hooked into the after_setup_theme hook, which
+	 * runs before the init hook. The init hook is too late for some features, such
+	 * as indicating support for post thumbnails.
+	 */
+	function twentyseventeen_setup() {
+		/*
+		 * Make theme available for translation.
+		 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentyseventeen
+		 * If you're building a theme based on Twenty Seventeen, use a find and replace
+		 * to change 'twentyseventeen' to the name of your theme in all the template files.
+		 */
+		load_theme_textdomain( 'twentyseventeen' );
 
+		// Add default posts and comments RSS feed links to head.
+		add_theme_support( 'automatic-feed-links' );
 
-/**
- * Set the content width in pixels, based on the theme's design and stylesheet.
- *
- * Priority 0 to make it available to lower priority callbacks.
- *
- * @global int $content_width
- */
-function twentyseventeen_content_width() {
-	$GLOBALS['content_width'] = apply_filters( 'twentyseventeen_content_width', 700 );
-}
-add_action( 'after_setup_theme', 'twentyseventeen_content_width', 0 );
+		/*
+		 * Let WordPress manage the document title.
+		 * By adding theme support, we declare that this theme does not use a
+		 * hard-coded <title> tag in the document head, and expect WordPress to
+		 * provide it for us.
+		 */
+		add_theme_support( 'title-tag' );
 
+		/*
+		 * Enable support for Post Thumbnails on posts and pages.
+		 *
+		 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
+		 */
+		add_theme_support( 'post-thumbnails' );
 
-/**
- * Register custom fonts
- */
-function twentyseventeen_fonts_url() {
-	$fonts_url = '';
+		add_image_size( 'twentyseventeen-featured-image', 2000, 1200, true );
+
+		add_image_size( 'twentyseventeen-thumbnail-avatar', 100, 100, true );
+
+		// This theme uses wp_nav_menu() in two locations.
+		register_nav_menus( array(
+			'top'    => __( 'Top', 'twentyseventeen' ),
+			'social' => __( 'Social Links Menu', 'twentyseventeen' ),
+		) );
+
+		/*
+		 * Switch default core markup for search form, comment form, and comments
+		 * to output valid HTML5.
+		 */
+		add_theme_support( 'html5', array(
+			'comment-form',
+			'comment-list',
+			'gallery',
+			'caption',
+		) );
+
+		/*
+		 * Enable support for Post Formats.
+		 *
+		 * See: https://codex.wordpress.org/Post_Formats
+		 */
+		add_theme_support( 'post-formats', array(
+			'aside',
+			'image',
+			'video',
+			'quote',
+			'link',
+			'gallery',
+			'audio',
+		) );
+
+		// Add theme support for Custom Logo.
+		add_theme_support( 'custom-logo', array(
+			'width'       => 1000,
+			'height'      => 1000,
+			'flex-width'  => true,
+			'flex-height' => true,
+		) );
+	}
+	endif;
+	add_action( 'after_setup_theme', 'twentyseventeen_setup' );
+
 
 	/**
-	 * Translators: If there are characters in your language that are not
-	 * supported by Libre Frankin, translate this to 'off'. Do not translate
-	 * into your own language.
+	 * Set the content width in pixels, based on the theme's design and stylesheet.
+	 *
+	 * Priority 0 to make it available to lower priority callbacks.
+	 *
+	 * @global int $content_width
 	 */
-	$libre_franklin = _x( 'on', 'libre_franklin font: on or off', 'twentyseventeen' );
+	function twentyseventeen_content_width() {
+		$GLOBALS['content_width'] = apply_filters( 'twentyseventeen_content_width', 700 );
+	}
+	add_action( 'after_setup_theme', 'twentyseventeen_content_width', 0 );
 
-	if ( 'off' !== $libre_franklin ) {
-		$font_families = array();
 
-		$font_families[] = 'Libre Franklin:300,300i,400,400i,600,600i,800,800i';
+	/**
+	 * Register custom fonts
+	 */
+	function twentyseventeen_fonts_url() {
+		$fonts_url = '';
 
-		$query_args = array(
-			'family' => urlencode( implode( '|', $font_families ) ),
-			'subset' => urlencode( 'latin,latin-ext' ),
-		);
+		/**
+		 * Translators: If there are characters in your language that are not
+		 * supported by Libre Frankin, translate this to 'off'. Do not translate
+		 * into your own language.
+		 */
+		$libre_franklin = _x( 'on', 'libre_franklin font: on or off', 'twentyseventeen' );
 
-		$fonts_url = add_query_arg( $query_args, 'https://fonts.googleapis.com/css' );
+		if ( 'off' !== $libre_franklin ) {
+			$font_families = array();
+
+			$font_families[] = 'Libre Franklin:300,300i,400,400i,600,600i,800,800i';
+
+			$query_args = array(
+				'family' => urlencode( implode( '|', $font_families ) ),
+				'subset' => urlencode( 'latin,latin-ext' ),
+			);
+
+			$fonts_url = add_query_arg( $query_args, 'https://fonts.googleapis.com/css' );
+		}
+
+		return esc_url_raw( $fonts_url );
 	}
 
-	return esc_url_raw( $fonts_url );
-}
+	/**
+	 * Register widget area.
+	 *
+	 * @link https://developer.wordpress.org/themes/functionality/sidebars/#registering-a-sidebar
+	 */
+	function twentyseventeen_widgets_init() {
+		register_sidebar( array(
+			'name'          => __( 'Sidebar', 'twentyseventeen' ),
+			'id'            => 'sidebar-1',
+			'description'   => '',
+			'before_widget' => '<section id="%1$s" class="widget %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h2 class="widget-title">',
+			'after_title'   => '</h2>',
+		) );
 
-/**
- * Register widget area.
- *
- * @link https://developer.wordpress.org/themes/functionality/sidebars/#registering-a-sidebar
- */
-function twentyseventeen_widgets_init() {
-	register_sidebar( array(
-		'name'          => __( 'Sidebar', 'twentyseventeen' ),
-		'id'            => 'sidebar-1',
-		'description'   => '',
-		'before_widget' => '<section id="%1$s" class="widget %2$s">',
-		'after_widget'  => '</section>',
-		'before_title'  => '<h2 class="widget-title">',
-		'after_title'   => '</h2>',
-	) );
+		register_sidebar( array(
+			'name'          => __( 'Footer 1', 'twentyseventeen' ),
+			'id'            => 'sidebar-2',
+			'description'   => '',
+			'before_widget' => '<section id="%1$s" class="widget %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h2 class="widget-title">',
+			'after_title'   => '</h2>',
+		) );
 
-	register_sidebar( array(
-		'name'          => __( 'Footer 1', 'twentyseventeen' ),
-		'id'            => 'sidebar-2',
-		'description'   => '',
-		'before_widget' => '<section id="%1$s" class="widget %2$s">',
-		'after_widget'  => '</section>',
-		'before_title'  => '<h2 class="widget-title">',
-		'after_title'   => '</h2>',
-	) );
-
-	register_sidebar( array(
-		'name'          => __( 'Footer 2', 'twentyseventeen' ),
-		'id'            => 'sidebar-3',
-		'description'   => '',
-		'before_widget' => '<section id="%1$s" class="widget %2$s">',
-		'after_widget'  => '</section>',
-		'before_title'  => '<h2 class="widget-title">',
-		'after_title'   => '</h2>',
-	) );
-}
-add_action( 'widgets_init', 'twentyseventeen_widgets_init' );
-
-
-/**
- * Output Custom Logo.
- */
-function twentyseventeen_the_custom_logo() {
-	if ( function_exists( 'the_custom_logo' ) ) {
-		the_custom_logo();
+		register_sidebar( array(
+			'name'          => __( 'Footer 2', 'twentyseventeen' ),
+			'id'            => 'sidebar-3',
+			'description'   => '',
+			'before_widget' => '<section id="%1$s" class="widget %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h2 class="widget-title">',
+			'after_title'   => '</h2>',
+		) );
 	}
-}
+	add_action( 'widgets_init', 'twentyseventeen_widgets_init' );
 
 
-if ( ! function_exists( 'twentyseventeen_excerpt_continue_reading' ) ) {
-/**
- * Replaces the excerpt "more" text by a link
- */
-function twentyseventeen_excerpt_continue_reading() {
-	return ' &hellip; <p class="link-more"><a href="' . esc_url( get_permalink() ) . '">' . sprintf( __( 'Continue reading %s', 'twentyseventeen' ), the_title( '<span class="screen-reader-text">"', '"</span>', false ) ) . '</a></p>';
-}
-}
-add_filter( 'excerpt_more', 'twentyseventeen_excerpt_continue_reading' );
-
-
-/**
- * Handles JavaScript detection.
- *
- * Adds a `js` class to the root `<html>` element when JavaScript is detected.
- *
- * @since Twenty Seventeen 1.0
- */
-function twentyseventeen_javascript_detection() {
-	echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>\n";
-}
-add_action( 'wp_head', 'twentyseventeen_javascript_detection', 0 );
-
-/**
- * Enqueue scripts and styles.
- */
-function twentyseventeen_scripts() {
-	// Add custom fonts, used in the main stylesheet.
-	wp_enqueue_style( 'twentyseventeen-fonts', twentyseventeen_fonts_url(), array(), null );
-
-	// Theme stylesheet.
-	wp_enqueue_style( 'twentyseventeen-style', get_stylesheet_uri() );
-
-	// Load the dark colorscheme.
-	if ( 'dark' === get_theme_mod( 'colorscheme', 'light' ) || is_customize_preview() ) {
-		wp_enqueue_style( 'twentyseventeen-colors-dark', get_template_directory_uri() . '/assets/css/colors-dark.css', array( 'twentyseventeen-style' ), '20161006' );
-	}
-
-	// Load the Internet Explorer 8 specific stylesheet.
-	wp_enqueue_style( 'twentyseventeen-ie8', get_template_directory_uri() . '/assets/css/ie8.css', array( 'twentyseventeen-style' ), '20160928' );
-	wp_style_add_data( 'twentyseventeen-ie8', 'conditional', 'lt IE 9' );
-
-	// Load the html5 shiv.
-	wp_enqueue_script( 'html5', get_template_directory_uri() . '/assets/js/html5.js', array(), '3.7.3' );
-	wp_script_add_data( 'html5', 'conditional', 'lt IE 9' );
-
-	wp_enqueue_script( 'twentyseventeen-skip-link-focus-fix', get_template_directory_uri() . '/assets/js/skip-link-focus-fix.js', array(), '20151215', true );
-
-	wp_enqueue_script( 'twentyseventeen-navigation', get_template_directory_uri() . '/assets/js/navigation.js', array(), '20151215', true );
-
-	wp_localize_script( 'twentyseventeen-navigation', 'twentyseventeenScreenReaderText', array(
-		'expand'   => __( 'Expand child menu', 'twentyseventeen' ),
-		'collapse' => __( 'Collapse child menu', 'twentyseventeen' ),
-		'icon'     => twentyseventeen_get_svg( array( 'icon' => 'expand' ) ),
-	) );
-
-	wp_enqueue_script( 'twentyseventeen-global', get_template_directory_uri() . '/assets/js/global.js', array( 'jquery' ), '20151215', true );
-
-	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
-		wp_enqueue_script( 'comment-reply' );
-	}
-
-	// Scroll effects (only loaded on front page).
-	if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) {
-		wp_enqueue_script( 'jquery-scrollto', get_template_directory_uri() . '/assets/js/jquery.scrollTo.js', array( 'jquery' ), '20151030', true );
-	}
-
-}
-add_action( 'wp_enqueue_scripts', 'twentyseventeen_scripts' );
-
-
-/**
- * Add custom image sizes attribute to enhance responsive image functionality
- * for content images
- *
- * @since Twenty Seventeen 1.0
- *
- * @param string $sizes A source size value for use in a 'sizes' attribute.
- * @param array  $size  Image size. Accepts an array of width and height
- *                      values in pixels (in that order).
- * @return string A source size value for use in a content image 'sizes' attribute.
- */
-function twentyseventeen_content_image_sizes_attr( $sizes, $size ) {
-	$width = $size[0];
-
-	740 <= $width && $sizes = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, 740px';
-
-	if ( is_active_sidebar( 'sidebar-1' ) || is_archive() || is_search() || is_home() || is_page() ) {
-		if ( ! ( is_page() && 'one-column' === get_theme_mod( 'page_options' ) ) ) {
-			767 <= $width && $sizes = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
+	/**
+	 * Output Custom Logo.
+	 */
+	function twentyseventeen_the_custom_logo() {
+		if ( function_exists( 'the_custom_logo' ) ) {
+			the_custom_logo();
 		}
 	}
 
-	return $sizes;
-}
-add_filter( 'wp_calculate_image_sizes', 'twentyseventeen_content_image_sizes_attr', 10 , 2 );
 
-/**
- * Add custom image sizes attribute to enhance responsive image functionality
- * for post thumbnails
- *
- * @since Twenty Seventeen 1.0
- *
- * @param array $attr Attributes for the image markup.
- * @param int   $attachment Image attachment ID.
- * @param array $size Registered image size or flat array of height and width dimensions.
- * @return string A source size value for use in a post thumbnail 'sizes' attribute.
- */
-function twentyseventeen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
-	if ( is_archive() || is_search() || is_home() ) {
-		$attr['sizes'] = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
-	} else {
-		$attr['sizes'] = '100vw';
+	if ( ! function_exists( 'twentyseventeen_excerpt_continue_reading' ) ) {
+	/**
+	 * Replaces the excerpt "more" text by a link
+	 */
+	function twentyseventeen_excerpt_continue_reading() {
+		return ' &hellip; <p class="link-more"><a href="' . esc_url( get_permalink() ) . '">' . sprintf( __( 'Continue reading %s', 'twentyseventeen' ), the_title( '<span class="screen-reader-text">"', '"</span>', false ) ) . '</a></p>';
 	}
-	return $attr;
+	}
+	add_filter( 'excerpt_more', 'twentyseventeen_excerpt_continue_reading' );
+
+
+	/**
+	 * Handles JavaScript detection.
+	 *
+	 * Adds a `js` class to the root `<html>` element when JavaScript is detected.
+	 *
+	 * @since Twenty Seventeen 1.0
+	 */
+	function twentyseventeen_javascript_detection() {
+		echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>\n";
+	}
+	add_action( 'wp_head', 'twentyseventeen_javascript_detection', 0 );
+
+	/**
+	 * Enqueue scripts and styles.
+	 */
+	function twentyseventeen_scripts() {
+		// Add custom fonts, used in the main stylesheet.
+		wp_enqueue_style( 'twentyseventeen-fonts', twentyseventeen_fonts_url(), array(), null );
+
+		// Theme stylesheet.
+		wp_enqueue_style( 'twentyseventeen-style', get_stylesheet_uri() );
+
+		// Load the dark colorscheme.
+		if ( 'dark' === get_theme_mod( 'colorscheme', 'light' ) || is_customize_preview() ) {
+			wp_enqueue_style( 'twentyseventeen-colors-dark', get_theme_file_uri( '/assets/css/colors-dark.css' ), array( 'twentyseventeen-style' ), '20161006' );
+		}
+
+		// Load the Internet Explorer 8 specific stylesheet.
+		wp_enqueue_style( 'twentyseventeen-ie8', get_theme_file_uri( '/assets/css/ie8.css' ), array( 'twentyseventeen-style' ), '20160928' );
+		wp_style_add_data( 'twentyseventeen-ie8', 'conditional', 'lt IE 9' );
+
+		// Load the html5 shiv.
+		wp_enqueue_script( 'html5', get_theme_file_uri( '/assets/js/html5.js' ), array(), '3.7.3' );
+		wp_script_add_data( 'html5', 'conditional', 'lt IE 9' );
+
+		wp_enqueue_script( 'twentyseventeen-skip-link-focus-fix', get_theme_file_uri( '/assets/js/skip-link-focus-fix.js' ), array(), '20151215', true );
+
+		wp_enqueue_script( 'twentyseventeen-navigation', get_theme_file_uri( '/assets/js/navigation.js' ), array(), '20151215', true );
+
+		wp_localize_script( 'twentyseventeen-navigation', 'twentyseventeenScreenReaderText', array(
+			'expand'   => __( 'Expand child menu', 'twentyseventeen' ),
+			'collapse' => __( 'Collapse child menu', 'twentyseventeen' ),
+			'icon'     => twentyseventeen_get_svg( array( 'icon' => 'expand' ) ),
+		) );
+
+		wp_enqueue_script( 'twentyseventeen-global', get_theme_file_uri( '/assets/js/global.js' ), array( 'jquery' ), '20151215', true );
+
+		if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
+			wp_enqueue_script( 'comment-reply' );
+		}
+
+		// Scroll effects (only loaded on front page).
+		if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) {
+			wp_enqueue_script( 'jquery-scrollto', get_theme_file_uri( '/assets/js/jquery.scrollTo.js' ), array( 'jquery' ), '20151030', true );
+		}
+
+	}
+	add_action( 'wp_enqueue_scripts', 'twentyseventeen_scripts' );
+
+
+	/**
+	 * Add custom image sizes attribute to enhance responsive image functionality
+	 * for content images
+	 *
+	 * @since Twenty Seventeen 1.0
+	 *
+	 * @param string $sizes A source size value for use in a 'sizes' attribute.
+	 * @param array  $size  Image size. Accepts an array of width and height
+	 *                      values in pixels (in that order).
+	 * @return string A source size value for use in a content image 'sizes' attribute.
+	 */
+	function twentyseventeen_content_image_sizes_attr( $sizes, $size ) {
+		$width = $size[0];
+
+		740 <= $width && $sizes = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, 740px';
+
+		if ( is_active_sidebar( 'sidebar-1' ) || is_archive() || is_search() || is_home() || is_page() ) {
+			if ( ! ( is_page() && 'one-column' === get_theme_mod( 'page_options' ) ) ) {
+				767 <= $width && $sizes = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
+			}
+		}
+
+		return $sizes;
+	}
+	add_filter( 'wp_calculate_image_sizes', 'twentyseventeen_content_image_sizes_attr', 10 , 2 );
+
+	/**
+	 * Add custom image sizes attribute to enhance responsive image functionality
+	 * for post thumbnails
+	 *
+	 * @since Twenty Seventeen 1.0
+	 *
+	 * @param array $attr Attributes for the image markup.
+	 * @param int   $attachment Image attachment ID.
+	 * @param array $size Registered image size or flat array of height and width dimensions.
+	 * @return string A source size value for use in a post thumbnail 'sizes' attribute.
+	 */
+	function twentyseventeen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
+		if ( is_archive() || is_search() || is_home() ) {
+			$attr['sizes'] = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
+		} else {
+			$attr['sizes'] = '100vw';
+		}
+		return $attr;
+	}
+	add_filter( 'wp_get_attachment_image_attributes', 'twentyseventeen_post_thumbnail_sizes_attr', 10 , 3 );
+
+
+	/**
+	 * Implement the Custom Header feature.
+	 */
+	require get_parent_theme_file_path( '/inc/custom-header.php' );
+
+	/**
+	 * Custom template tags for this theme.
+	 */
+	require get_parent_theme_file_path( '/inc/template-tags.php' );
+
+	/**
+	 * Custom functions that act independently of the theme templates.
+	 */
+	require get_parent_theme_file_path( '/inc/extras.php' );
+
+	/**
+	 * Customizer additions.
+	 */
+	require get_parent_theme_file_path( '/inc/customizer.php' );
+
+	/**
+	 * SVG icons functions and filters.
+	 */
+	require get_parent_theme_file_path( '/inc/functions-icons.php' );
+
 }
-add_filter( 'wp_get_attachment_image_attributes', 'twentyseventeen_post_thumbnail_sizes_attr', 10 , 3 );
-
-
-/**
- * Implement the Custom Header feature.
- */
-require get_template_directory() . '/inc/custom-header.php';
-
-/**
- * Custom template tags for this theme.
- */
-require get_template_directory() . '/inc/template-tags.php';
-
-/**
- * Custom functions that act independently of the theme templates.
- */
-require get_template_directory() . '/inc/extras.php';
-
-/**
- * Customizer additions.
- */
-require get_template_directory() . '/inc/customizer.php';
-
-/**
- * SVG icons functions and filters.
- */
-require get_template_directory() . '/inc/functions-icons.php';

--- a/inc/back-compat.php
+++ b/inc/back-compat.php
@@ -10,6 +10,7 @@
  * @subpackage Twenty_Seventeen
  * @since Twenty Seventeen 1.0
  */
+
 /**
  * Prevent switching to Twenty Seventeen on old versions of WordPress.
  *
@@ -23,6 +24,7 @@ function twentyseventeen_switch_theme() {
 	add_action( 'admin_notices', 'twentyseventeen_upgrade_notice' );
 }
 add_action( 'after_switch_theme', 'twentyseventeen_switch_theme' );
+
 /**
  * Adds a message for unsuccessful theme switch.
  *
@@ -37,6 +39,7 @@ function twentyseventeen_upgrade_notice() {
 	$message = sprintf( __( 'Twenty Seventeen requires at least WordPress version 4.7. You are running version %s. Please upgrade and try again.', 'twentyseventeen' ), $GLOBALS['wp_version'] );
 	printf( '<div class="error"><p>%s</p></div>', $message );
 }
+
 /**
  * Prevents the Customizer from being loaded on WordPress versions prior to 4.7.
  *
@@ -50,6 +53,7 @@ function twentyseventeen_customize() {
 	) );
 }
 add_action( 'load-customize.php', 'twentyseventeen_customize' );
+
 /**
  * Prevents the Theme Preview from being loaded on WordPress versions prior to 4.7.
  *

--- a/inc/back-compat.php
+++ b/inc/back-compat.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Twenty Seventeen back compat functionality
+ *
+ * Prevents Twenty Seventeen from running on WordPress versions prior to 4.7,
+ * since this theme is not meant to be backward compatible beyond that and
+ * relies on many newer functions and markup changes introduced in 4.7.
+ *
+ * @package WordPress
+ * @subpackage Twenty_Seventeen
+ * @since Twenty Seventeen 1.0
+ */
+/**
+ * Prevent switching to Twenty Seventeen on old versions of WordPress.
+ *
+ * Switches to the default theme.
+ *
+ * @since Twenty Seventeen 1.0
+ */
+function twentyseventeen_switch_theme() {
+	switch_theme( WP_DEFAULT_THEME, WP_DEFAULT_THEME );
+	unset( $_GET['activated'] );
+	add_action( 'admin_notices', 'twentyseventeen_upgrade_notice' );
+}
+add_action( 'after_switch_theme', 'twentyseventeen_switch_theme' );
+/**
+ * Adds a message for unsuccessful theme switch.
+ *
+ * Prints an update nag after an unsuccessful attempt to switch to
+ * Twenty Seventeen on WordPress versions prior to 4.7.
+ *
+ * @since Twenty Seventeen 1.0
+ *
+ * @global string $wp_version WordPress version.
+ */
+function twentyseventeen_upgrade_notice() {
+	$message = sprintf( __( 'Twenty Seventeen requires at least WordPress version 4.7. You are running version %s. Please upgrade and try again.', 'twentyseventeen' ), $GLOBALS['wp_version'] );
+	printf( '<div class="error"><p>%s</p></div>', $message );
+}
+/**
+ * Prevents the Customizer from being loaded on WordPress versions prior to 4.7.
+ *
+ * @since Twenty Seventeen 1.0
+ *
+ * @global string $wp_version WordPress version.
+ */
+function twentyseventeen_customize() {
+	wp_die( sprintf( __( 'Twenty Seventeen requires at least WordPress version 4.7. You are running version %s. Please upgrade and try again.', 'twentyseventeen' ), $GLOBALS['wp_version'] ), '', array(
+		'back_link' => true,
+	) );
+}
+add_action( 'load-customize.php', 'twentyseventeen_customize' );
+/**
+ * Prevents the Theme Preview from being loaded on WordPress versions prior to 4.7.
+ *
+ * @since Twenty Seventeen 1.0
+ *
+ * @global string $wp_version WordPress version.
+ */
+function twentyseventeen_preview() {
+	if ( isset( $_GET['preview'] ) ) {
+		wp_die( sprintf( __( 'Twenty Seventeen requires at least WordPress version 4.7. You are running version %s. Please upgrade and try again.', 'twentyseventeen' ), $GLOBALS['wp_version'] ) );
+	}
+}
+add_action( 'template_redirect', 'twentyseventeen_preview' );

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -16,7 +16,7 @@
  */
 function twentyseventeen_custom_header_setup() {
 	add_theme_support( 'custom-header', apply_filters( 'twentyseventeen_custom_header_args', array(
-		'default-image'      => get_template_directory_uri() . '/assets/images/header.jpg',
+		'default-image'      => get_parent_theme_file_uri( '/assets/images/header.jpg' ),
 		'default-text-color' => '222222',
 		'width'              => 2000,
 		'height'             => 1200,

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -207,7 +207,7 @@ function twentyseventeen_is_page() {
  * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
  */
 function twentyseventeen_customize_preview_js() {
-	wp_enqueue_script( 'twentyseventeen-customizer', get_template_directory_uri() . '/assets/js/customizer.js', array( 'customize-preview' ), '20151215', true );
+	wp_enqueue_script( 'twentyseventeen-customizer', get_theme_file_uri( '/assets/js/customizer.js' ), array( 'customize-preview' ), '20151215', true );
 }
 add_action( 'customize_preview_init', 'twentyseventeen_customize_preview_js' );
 
@@ -215,7 +215,7 @@ add_action( 'customize_preview_init', 'twentyseventeen_customize_preview_js' );
  * Some extra JavaScript to improve the user experience in the Customizer for this theme.
  */
 function twentyseventeen_panels_js() {
-	wp_enqueue_script( 'twentyseventeen-panel-customizer', get_template_directory_uri() . '/assets/js/panel-customizer.js', array(), '20151116', true );
+	wp_enqueue_script( 'twentyseventeen-panel-customizer', get_theme_file_uri( '/assets/js/panel-customizer.js' ), array(), '20151116', true );
 }
 add_action( 'customize_controls_enqueue_scripts', 'twentyseventeen_panels_js' );
 

--- a/inc/functions-icons.php
+++ b/inc/functions-icons.php
@@ -13,7 +13,7 @@
 function twentyseventeen_include_svg_icons() {
 
 	// Define SVG sprite file.
-	$svg_icons = get_template_directory() . '/assets/images/svg-icons.svg';
+	$svg_icons = get_parent_theme_file_path( '/assets/images/svg-icons.svg' );
 
 	// If it exists, include it.
 	if ( file_exists( $svg_icons ) ) {
@@ -87,7 +87,7 @@ function twentyseventeen_get_svg( $args = array() ) {
 
 	// Use absolute path in the Customizer so that icons show up in there.
 	if ( is_customize_preview() ) {
-		$svg .= '<use xlink:href="' . get_template_directory_uri() . '/assets/images/svg-icons.svg' . '#icon-' . esc_html( $args['icon'] ) . '"></use>';
+		$svg .= '<use xlink:href="' . get_parent_theme_file_uri( '/assets/images/svg-icons.svg' ) . '#icon-' . esc_html( $args['icon'] ) . '"></use>';
 	} else {
 		$svg .= '<use xlink:href="#icon-' . esc_html( $args['icon'] ) . '"></use>';
 	}

--- a/inc/functions-icons.php
+++ b/inc/functions-icons.php
@@ -87,7 +87,7 @@ function twentyseventeen_get_svg( $args = array() ) {
 
 	// Use absolute path in the Customizer so that icons show up in there.
 	if ( is_customize_preview() ) {
-		$svg .= '<use xlink:href="' . get_parent_theme_file_uri( '/assets/images/svg-icons.svg' ) . '#icon-' . esc_html( $args['icon'] ) . '"></use>';
+		$svg .= '<use xlink:href="' . get_parent_theme_file_uri( '/assets/images/svg-icons.svg#icon-' . esc_html( $args['icon'] ) ) . '"></use>';
 	} else {
 		$svg .= '<use xlink:href="#icon-' . esc_html( $args['icon'] ) . '"></use>';
 	}


### PR DESCRIPTION
- Also, add `back-compat.php` file. Twenty Seventeen can only be used in 4.7.
- Also uses `the_custom_logo` instead if custom function.
- Cleans up some spacing.

Closes #176.

See #287.
