### PR TITLE
Add dropdown icon for page items which has children v2

### DIFF
--- a/components/navigation/navigation-top.php
+++ b/components/navigation/navigation-top.php
@@ -14,6 +14,7 @@
 	<?php wp_nav_menu( array(
 		'theme_location' => 'top',
 		'menu_id'        => 'top-menu',
+		'fallback_cb'    => wp_page_menu( array( 'link_after' => twentyseventeen_get_svg( array( 'icon' => 'expand' ) ) ) ),
 	) ); ?>
 
 	<?php if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) : ?>

--- a/style.css
+++ b/style.css
@@ -1023,7 +1023,8 @@ a:hover .nav-title,
 
 .js .main-navigation ul,
 .main-navigation .menu-item-has-children > a > .icon,
-.main-navigation .page_item_has_children > a > .icon  {
+.main-navigation .page_item_has_children > a > .icon,
+.main-navigation a > .icon {
 	display: none;
 }
 


### PR DESCRIPTION
Add dropdown icon for page items which has children using `link_after` in `wp_page_menu` fallback. This is v2 for issue #323.
