### PR TITLE
Scaling down logo and getting it to sit beside site title

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -47,3 +47,4 @@ Version 1.0:
 @yoavf
 @karmatosed
 @sandesh055
+@adammacias

--- a/assets/css/editor-style.css
+++ b/assets/css/editor-style.css
@@ -1,0 +1,415 @@
+/*
+Theme Name: Twenty Seventeen
+Description: Used to style the TinyMCE editor.
+*/
+
+
+/**
+ * Table of Contents:
+ *
+ * 1.0 - Body
+ * 2.0 - Typography
+ * 3.0 - Elements
+ * 4.0 - Alignment
+ * 5.0 - Caption
+ * 6.0 - Galleries
+ * 7.0 - Media Elements
+ * 8.0 - RTL
+ */
+
+/**
+ * 1.0 - Body
+ */
+
+body {
+	background-color: #fff;
+	color: #333;
+	margin: 20px 40px;
+	max-width: 580px;
+}
+
+/**
+ * 2.0 - Typography
+ */
+
+body,
+button,
+input,
+select,
+textarea {
+	font-family: "Libre Franklin", "Helvetica Neue", helvetica, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: normal;
+	line-height: 1.66;
+}
+
+h1, h2, h3, h4, h5, h6 {
+	clear: both;
+	line-height: 1.4;
+	margin: 0 0 0.75em;
+	padding: 1.5em 0 0 0;
+}
+
+h1:first-child,
+h2:first-child,
+h3:first-child,
+h4:first-child,
+h5:first-child,
+h6:first-child {
+	padding-top: 0;
+}
+
+h1 {
+	font-size: 24px;
+	font-size: 1.5rem;
+	font-weight: 300;
+}
+
+h2 {
+	color: #666;
+	font-size: 20px;
+	font-size: 1.25rem;
+	font-weight: 300;
+}
+
+h3 {
+	color: #333;
+	font-size: 18px;
+	font-size: 1.125rem;
+	font-weight: 300;
+}
+
+h4 {
+	color: #333;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 800;
+}
+
+h5 {
+	color: #767676;
+	font-size: 13px;
+	font-size: 0.8125rem;
+	font-weight: 800;
+	letter-spacing: 0.15em;
+	text-transform: uppercase;
+}
+
+h6 {
+	color: #333;
+	font-size: 15px;
+	font-size: 0.9375rem;
+	font-weight: 800;
+}
+
+p {
+	margin: 0 0 1.5em;
+	padding: 0;
+}
+
+dfn, cite, em, i {
+	font-style: italic;
+}
+
+blockquote {
+	color: #666;
+	font-size: 18px;
+	font-size: 1.125rem;
+	font-style: italic;
+	line-height: 1.7;
+	margin: 0;
+	overflow: hidden;
+	padding: 0;
+}
+
+blockquote.alignleft,
+blockquote.alignright {
+	font-size: 14px;
+	font-size: 0.875rem;
+	width: 34%;
+}
+
+address {
+	margin: 0 0 1.5em;
+}
+
+pre {
+	background: #eee;
+	font-family: "Courier 10 Pitch", Courier, monospace;
+	font-size: 15px;
+	font-size: 0.9375rem;
+	line-height: 1.6;
+	margin-bottom: 1.6em;
+	max-width: 100%;
+	overflow: auto;
+	padding: 1.6em;
+}
+
+code, kbd, tt, var {
+	font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
+	font-size: 15px;
+	font-size: 0.9375rem;
+}
+
+abbr, acronym {
+	border-bottom: 1px dotted #666;
+	cursor: help;
+}
+
+mark, ins {
+	background: #eee;
+	text-decoration: none;
+}
+
+big {
+	font-size: 125%;
+}
+
+blockquote, q {
+	quotes: "" "";
+}
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+	content: "";
+}
+
+/* Typography for Thai Font */
+
+html[lang="th"] h1,
+html[lang="th"] h2,
+html[lang="th"] h3,
+html[lang="th"] h4,
+html[lang="th"] h5,
+html[lang="th"] h6 {
+	letter-spacing: 0;
+	line-height: 1.65;
+}
+
+html[lang="th"] body,
+html[lang="th"] button,
+html[lang="th"] input,
+html[lang="th"] select,
+html[lang="th"] textarea {
+	line-height: 1.8;
+}
+
+/**
+ * 3.0 - Elements
+ */
+
+hr {
+	background-color: #bbb;
+	border: 0;
+	height: 1px;
+	margin-bottom: 1.5em;
+}
+
+ul,
+ol {
+	margin: 0 0 1.5em;
+	padding: 0;
+}
+
+ul {
+	list-style: disc;
+}
+
+ol {
+	counter-reset: item;
+}
+
+ol li {
+	display: block;
+	position: relative;
+}
+
+ol li:before {
+	content: counter(item);
+	counter-increment: item;
+	font-weight: 800;
+	left: -1.5em;
+	position: absolute;
+}
+
+li > ul,
+li > ol {
+	margin-bottom: 0;
+	margin-left: 1.5em;
+}
+
+dt {
+	font-weight: bold;
+}
+
+dd {
+	margin: 0 1.5em 1.5em;
+}
+
+table {
+	margin: 0 0 1.5em;
+	width: 100%;
+}
+
+a {
+	border-bottom: 2px solid #767676;
+	color: #222;
+	text-decoration: none;
+	-webkit-transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
+	transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
+}
+
+a:focus {
+	outline: thin dotted;
+}
+
+a:hover,
+a:focus {
+	border-bottom-color: transparent;
+	background-color: #767676;
+	color: #fff;
+}
+
+/* Fixes linked images */
+
+a img {
+	background: #fff;
+	box-shadow: 0 0 0 6px #fff;
+}
+
+/**
+ * 4.0 - Alignment
+ */
+
+img {
+	height: auto; /* Make sure images are scaled correctly. */
+	width: inherit;  /* Make images fill their parent's space. Solves IE8. */
+	max-width: 100%; /* Adhere to container width. */
+}
+
+embed,
+iframe,
+object {
+	margin-bottom: 1.5em;
+	max-width: 100%;
+}
+
+/**
+ * 5.0 - Caption
+ */
+
+.wp-caption {
+	color: #666;
+	font-size: 13px;
+	font-size: 0.8125rem;
+	font-style: italic;
+	margin-bottom: 1.5em;
+	max-width: 100%;
+}
+
+.wp-caption img[class*="wp-image-"] {
+	display: block;
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.wp-caption .wp-caption-text {
+	margin: 0.8075em 0;
+}
+
+/**
+ * 6.0 - Galleries
+ */
+
+ .gallery {
+	margin-bottom: 1.5em;
+}
+
+.gallery-item {
+	display: inline-block;
+	text-align: center;
+	vertical-align: top;
+	width: 100%;
+}
+
+.gallery-columns-2 .gallery-item {
+	max-width: 50%;
+}
+
+.gallery-columns-3 .gallery-item {
+	max-width: 33.33%;
+}
+
+.gallery-columns-4 .gallery-item {
+	max-width: 25%;
+}
+
+.gallery-columns-5 .gallery-item {
+	max-width: 20%;
+}
+
+.gallery-columns-6 .gallery-item {
+	max-width: 16.66%;
+}
+
+.gallery-columns-7 .gallery-item {
+	max-width: 14.28%;
+}
+
+.gallery-columns-8 .gallery-item {
+	max-width: 12.5%;
+}
+
+.gallery-columns-9 .gallery-item {
+	max-width: 11.11%;
+}
+
+.gallery-caption {
+	display: block;
+}
+
+/**
+ * 7.0 - Media Elements
+ */
+
+.mejs-container {
+	margin-bottom: 1.5em;
+}
+
+/* Audio Player */
+
+.mejs-controls a.mejs-horizontal-volume-slider,
+.mejs-controls a.mejs-horizontal-volume-slider:focus,
+.mejs-controls a.mejs-horizontal-volume-slider:hover {
+	background: transparent;
+	border: 0;
+}
+
+/**
+ * 8.0 - RTL
+ */
+
+.rtl th {
+	text-align: right;
+}
+
+.rtl ol {
+	counter-reset: item;
+}
+
+.rtl ol li:before {
+	left: auto;
+	right: -1.5em;
+}
+
+.rtl li > ul,
+.rtl li > ol {
+	margin-left: 0;
+	margin-right: 1.5em;
+}
+
+.rtl .mejs-offscreen {
+	right: -10000px;
+}

--- a/assets/css/editor-style.css
+++ b/assets/css/editor-style.css
@@ -40,15 +40,20 @@ textarea {
 	font-family: "Libre Franklin", "Helvetica Neue", helvetica, arial, sans-serif;
 	font-size: 16px;
 	font-size: 1rem;
-	font-weight: normal;
+	font-weight: 400;
 	line-height: 1.66;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
 	clear: both;
 	line-height: 1.4;
 	margin: 0 0 0.75em;
-	padding: 1.5em 0 0 0;
+	padding: 1.5em 0 0;
 }
 
 h1:first-child,
@@ -108,7 +113,10 @@ p {
 	padding: 0;
 }
 
-dfn, cite, em, i {
+dfn,
+cite,
+em,
+i {
 	font-style: italic;
 }
 
@@ -146,18 +154,23 @@ pre {
 	padding: 1.6em;
 }
 
-code, kbd, tt, var {
+code,
+kbd,
+tt,
+var {
 	font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
 	font-size: 15px;
 	font-size: 0.9375rem;
 }
 
-abbr, acronym {
+abbr,
+acronym {
 	border-bottom: 1px dotted #666;
 	cursor: help;
 }
 
-mark, ins {
+mark,
+ins {
 	background: #eee;
 	text-decoration: none;
 }
@@ -166,9 +179,11 @@ big {
 	font-size: 125%;
 }
 
-blockquote, q {
+blockquote,
+q {
 	quotes: "" "";
 }
+
 blockquote:before,
 blockquote:after,
 q:before,
@@ -241,7 +256,7 @@ li > ol {
 }
 
 dt {
-	font-weight: bold;
+	font-weight: 700;
 }
 
 dd {
@@ -323,7 +338,7 @@ object {
  * 6.0 - Galleries
  */
 
- .gallery {
+.gallery {
 	margin-bottom: 1.5em;
 }
 

--- a/assets/css/ie8.css
+++ b/assets/css/ie8.css
@@ -95,6 +95,10 @@ time.published {
 	z-index: -1;
 }
 
+img {
+	width: inherit;  /* Make images fill their parent's space. */
+}
+
 /* Fixes linked images */
 .entry-content a img,
 .widget a img {

--- a/assets/js/customizer.js
+++ b/assets/js/customizer.js
@@ -51,6 +51,7 @@
 					'clip': 'rect(1px, 1px, 1px, 1px)',
 					'position': 'absolute'
 				} );
+				$( 'body' ).addClass( 'title-tagline-hidden' );
 			} else {
 				$( '.site-title, .site-description' ).css( {
 					'clip': 'auto',
@@ -59,6 +60,7 @@
 				$( '.site-branding, .site-branding a, .site-description, .site-description a' ).css( {
 					'color': to
 				} );
+				$( 'body' ).removeClass( 'title-tagline-hidden' );
 			}
 		} );
 	} );

--- a/components/header/site-branding.php
+++ b/components/header/site-branding.php
@@ -12,7 +12,7 @@
 <div class="site-branding">
 	<div class="wrap">
 
-		<?php twentyseventeen_the_custom_logo(); ?>
+		<?php the_custom_logo(); ?>
 
 		<?php if ( is_front_page() ) : ?>
 			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>

--- a/components/header/site-branding.php
+++ b/components/header/site-branding.php
@@ -14,16 +14,18 @@
 
 		<?php twentyseventeen_the_custom_logo(); ?>
 
-		<?php if ( is_front_page() ) : ?>
-			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
-		<?php else : ?>
-			<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
-		<?php endif; ?>
+		<div class="site-branding-text">
+			<?php if ( is_front_page() ) : ?>
+				<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+			<?php else : ?>
+				<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
+			<?php endif; ?>
 
-		<?php $description = get_bloginfo( 'description', 'display' );
-			if ( $description || is_customize_preview() ) : ?>
-				<p class="site-description"><?php echo $description; /* WPCS: xss ok. */ ?></p>
-		<?php endif; ?>
+			<?php $description = get_bloginfo( 'description', 'display' );
+				if ( $description || is_customize_preview() ) : ?>
+					<p class="site-description"><?php echo $description; /* WPCS: xss ok. */ ?></p>
+			<?php endif; ?>
+		</div><!-- .site-branding-text -->
 
 	</div><!-- .wrap -->
 </div><!-- .site-branding -->

--- a/components/header/site-branding.php
+++ b/components/header/site-branding.php
@@ -14,16 +14,18 @@
 
 		<?php the_custom_logo(); ?>
 
-		<?php if ( is_front_page() ) : ?>
-			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
-		<?php else : ?>
-			<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
-		<?php endif; ?>
+		<div class="site-branding-text">
+			<?php if ( is_front_page() ) : ?>
+				<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+			<?php else : ?>
+				<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
+			<?php endif; ?>
 
-		<?php $description = get_bloginfo( 'description', 'display' );
-			if ( $description || is_customize_preview() ) : ?>
-				<p class="site-description"><?php echo $description; /* WPCS: xss ok. */ ?></p>
-		<?php endif; ?>
+			<?php $description = get_bloginfo( 'description', 'display' );
+				if ( $description || is_customize_preview() ) : ?>
+					<p class="site-description"><?php echo $description; /* WPCS: xss ok. */ ?></p>
+			<?php endif; ?>
+		</div><!-- .site-branding-text -->
 
 	</div><!-- .wrap -->
 </div><!-- .site-branding -->

--- a/functions.php
+++ b/functions.php
@@ -87,6 +87,12 @@ function twentyseventeen_setup() {
 		'flex-width'  => true,
 		'flex-height' => true,
 	) );
+
+	/*
+	 * This theme styles the visual editor to resemble the theme style,
+	 * specifically font, colors, and column width.
+ 	*/
+	add_editor_style( array( 'assets/css/editor-style.css', twentyseventeen_fonts_url() ) );
 }
 endif;
 add_action( 'after_setup_theme', 'twentyseventeen_setup' );

--- a/functions.php
+++ b/functions.php
@@ -231,7 +231,7 @@ function twentyseventeen_colors_css_wrap() {
 		return;
 	}
 
-	require_once( 'inc/color-patterns.php' );
+	require_once( get_parent_theme_file_path( '/inc/color-patterns.php' ) );
 	$hue = absint( get_theme_mod( 'colorscheme_hue', 250 ) );
 ?>
 	<style type="text/css" id="custom-theme-colors" <?php if ( is_customize_preview() ) { echo 'data-hue="' . $hue . '"'; } ?>>

--- a/functions.php
+++ b/functions.php
@@ -13,337 +13,307 @@
  * Twenty Seventeen only works in WordPress 4.7 or later.
  */
 if ( version_compare( $GLOBALS['wp_version'], '4.7-alpha', '<' ) ) {
-
 	require get_template_directory() . '/inc/back-compat.php';
-
-} else {
-
-	/**
-	 * Twenty Seventeen functions and definitions
-	 *
-	 * @link https://developer.wordpress.org/themes/basics/theme-functions/
-	 *
-	 * @package WordPress
-	 * @subpackage Twenty_Seventeen
-	 * @since 1.0
-	 */
-
-	if ( ! function_exists( 'twentyseventeen_setup' ) ) :
-	/**
-	 * Sets up theme defaults and registers support for various WordPress features.
-	 *
-	 * Note that this function is hooked into the after_setup_theme hook, which
-	 * runs before the init hook. The init hook is too late for some features, such
-	 * as indicating support for post thumbnails.
-	 */
-	function twentyseventeen_setup() {
-		/*
-		 * Make theme available for translation.
-		 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentyseventeen
-		 * If you're building a theme based on Twenty Seventeen, use a find and replace
-		 * to change 'twentyseventeen' to the name of your theme in all the template files.
-		 */
-		load_theme_textdomain( 'twentyseventeen' );
-
-		// Add default posts and comments RSS feed links to head.
-		add_theme_support( 'automatic-feed-links' );
-
-		/*
-		 * Let WordPress manage the document title.
-		 * By adding theme support, we declare that this theme does not use a
-		 * hard-coded <title> tag in the document head, and expect WordPress to
-		 * provide it for us.
-		 */
-		add_theme_support( 'title-tag' );
-
-		/*
-		 * Enable support for Post Thumbnails on posts and pages.
-		 *
-		 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
-		 */
-		add_theme_support( 'post-thumbnails' );
-
-		add_image_size( 'twentyseventeen-featured-image', 2000, 1200, true );
-
-		add_image_size( 'twentyseventeen-thumbnail-avatar', 100, 100, true );
-
-		// This theme uses wp_nav_menu() in two locations.
-		register_nav_menus( array(
-			'top'    => __( 'Top', 'twentyseventeen' ),
-			'social' => __( 'Social Links Menu', 'twentyseventeen' ),
-		) );
-
-		/*
-		 * Switch default core markup for search form, comment form, and comments
-		 * to output valid HTML5.
-		 */
-		add_theme_support( 'html5', array(
-			'comment-form',
-			'comment-list',
-			'gallery',
-			'caption',
-		) );
-
-		/*
-		 * Enable support for Post Formats.
-		 *
-		 * See: https://codex.wordpress.org/Post_Formats
-		 */
-		add_theme_support( 'post-formats', array(
-			'aside',
-			'image',
-			'video',
-			'quote',
-			'link',
-			'gallery',
-			'audio',
-		) );
-
-		// Add theme support for Custom Logo.
-		add_theme_support( 'custom-logo', array(
-			'width'       => 1000,
-			'height'      => 1000,
-			'flex-width'  => true,
-			'flex-height' => true,
-		) );
-	}
-	endif;
-	add_action( 'after_setup_theme', 'twentyseventeen_setup' );
-
-
-	/**
-	 * Set the content width in pixels, based on the theme's design and stylesheet.
-	 *
-	 * Priority 0 to make it available to lower priority callbacks.
-	 *
-	 * @global int $content_width
-	 */
-	function twentyseventeen_content_width() {
-		$GLOBALS['content_width'] = apply_filters( 'twentyseventeen_content_width', 700 );
-	}
-	add_action( 'after_setup_theme', 'twentyseventeen_content_width', 0 );
-
-
-	/**
-	 * Register custom fonts
-	 */
-	function twentyseventeen_fonts_url() {
-		$fonts_url = '';
-
-		/**
-		 * Translators: If there are characters in your language that are not
-		 * supported by Libre Frankin, translate this to 'off'. Do not translate
-		 * into your own language.
-		 */
-		$libre_franklin = _x( 'on', 'libre_franklin font: on or off', 'twentyseventeen' );
-
-		if ( 'off' !== $libre_franklin ) {
-			$font_families = array();
-
-			$font_families[] = 'Libre Franklin:300,300i,400,400i,600,600i,800,800i';
-
-			$query_args = array(
-				'family' => urlencode( implode( '|', $font_families ) ),
-				'subset' => urlencode( 'latin,latin-ext' ),
-			);
-
-			$fonts_url = add_query_arg( $query_args, 'https://fonts.googleapis.com/css' );
-		}
-
-		return esc_url_raw( $fonts_url );
-	}
-
-	/**
-	 * Register widget area.
-	 *
-	 * @link https://developer.wordpress.org/themes/functionality/sidebars/#registering-a-sidebar
-	 */
-	function twentyseventeen_widgets_init() {
-		register_sidebar( array(
-			'name'          => __( 'Sidebar', 'twentyseventeen' ),
-			'id'            => 'sidebar-1',
-			'description'   => '',
-			'before_widget' => '<section id="%1$s" class="widget %2$s">',
-			'after_widget'  => '</section>',
-			'before_title'  => '<h2 class="widget-title">',
-			'after_title'   => '</h2>',
-		) );
-
-		register_sidebar( array(
-			'name'          => __( 'Footer 1', 'twentyseventeen' ),
-			'id'            => 'sidebar-2',
-			'description'   => '',
-			'before_widget' => '<section id="%1$s" class="widget %2$s">',
-			'after_widget'  => '</section>',
-			'before_title'  => '<h2 class="widget-title">',
-			'after_title'   => '</h2>',
-		) );
-
-		register_sidebar( array(
-			'name'          => __( 'Footer 2', 'twentyseventeen' ),
-			'id'            => 'sidebar-3',
-			'description'   => '',
-			'before_widget' => '<section id="%1$s" class="widget %2$s">',
-			'after_widget'  => '</section>',
-			'before_title'  => '<h2 class="widget-title">',
-			'after_title'   => '</h2>',
-		) );
-	}
-	add_action( 'widgets_init', 'twentyseventeen_widgets_init' );
-
-
-	/**
-	 * Output Custom Logo.
-	 */
-	function twentyseventeen_the_custom_logo() {
-		if ( function_exists( 'the_custom_logo' ) ) {
-			the_custom_logo();
-		}
-	}
-
-
-	if ( ! function_exists( 'twentyseventeen_excerpt_continue_reading' ) ) {
-	/**
-	 * Replaces the excerpt "more" text by a link
-	 */
-	function twentyseventeen_excerpt_continue_reading() {
-		return ' &hellip; <p class="link-more"><a href="' . esc_url( get_permalink() ) . '">' . sprintf( __( 'Continue reading %s', 'twentyseventeen' ), the_title( '<span class="screen-reader-text">"', '"</span>', false ) ) . '</a></p>';
-	}
-	}
-	add_filter( 'excerpt_more', 'twentyseventeen_excerpt_continue_reading' );
-
-
-	/**
-	 * Handles JavaScript detection.
-	 *
-	 * Adds a `js` class to the root `<html>` element when JavaScript is detected.
-	 *
-	 * @since Twenty Seventeen 1.0
-	 */
-	function twentyseventeen_javascript_detection() {
-		echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>\n";
-	}
-	add_action( 'wp_head', 'twentyseventeen_javascript_detection', 0 );
-
-	/**
-	 * Enqueue scripts and styles.
-	 */
-	function twentyseventeen_scripts() {
-		// Add custom fonts, used in the main stylesheet.
-		wp_enqueue_style( 'twentyseventeen-fonts', twentyseventeen_fonts_url(), array(), null );
-
-		// Theme stylesheet.
-		wp_enqueue_style( 'twentyseventeen-style', get_stylesheet_uri() );
-
-		// Load the dark colorscheme.
-		if ( 'dark' === get_theme_mod( 'colorscheme', 'light' ) || is_customize_preview() ) {
-			wp_enqueue_style( 'twentyseventeen-colors-dark', get_theme_file_uri( '/assets/css/colors-dark.css' ), array( 'twentyseventeen-style' ), '20161006' );
-		}
-
-		// Load the Internet Explorer 8 specific stylesheet.
-		wp_enqueue_style( 'twentyseventeen-ie8', get_theme_file_uri( '/assets/css/ie8.css' ), array( 'twentyseventeen-style' ), '20160928' );
-		wp_style_add_data( 'twentyseventeen-ie8', 'conditional', 'lt IE 9' );
-
-		// Load the html5 shiv.
-		wp_enqueue_script( 'html5', get_theme_file_uri( '/assets/js/html5.js' ), array(), '3.7.3' );
-		wp_script_add_data( 'html5', 'conditional', 'lt IE 9' );
-
-		wp_enqueue_script( 'twentyseventeen-skip-link-focus-fix', get_theme_file_uri( '/assets/js/skip-link-focus-fix.js' ), array(), '20151215', true );
-
-		wp_enqueue_script( 'twentyseventeen-navigation', get_theme_file_uri( '/assets/js/navigation.js' ), array(), '20151215', true );
-
-		wp_localize_script( 'twentyseventeen-navigation', 'twentyseventeenScreenReaderText', array(
-			'expand'   => __( 'Expand child menu', 'twentyseventeen' ),
-			'collapse' => __( 'Collapse child menu', 'twentyseventeen' ),
-			'icon'     => twentyseventeen_get_svg( array( 'icon' => 'expand' ) ),
-		) );
-
-		wp_enqueue_script( 'twentyseventeen-global', get_theme_file_uri( '/assets/js/global.js' ), array( 'jquery' ), '20151215', true );
-
-		if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
-			wp_enqueue_script( 'comment-reply' );
-		}
-
-		// Scroll effects (only loaded on front page).
-		if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) {
-			wp_enqueue_script( 'jquery-scrollto', get_theme_file_uri( '/assets/js/jquery.scrollTo.js' ), array( 'jquery' ), '20151030', true );
-		}
-
-	}
-	add_action( 'wp_enqueue_scripts', 'twentyseventeen_scripts' );
-
-
-	/**
-	 * Add custom image sizes attribute to enhance responsive image functionality
-	 * for content images
-	 *
-	 * @since Twenty Seventeen 1.0
-	 *
-	 * @param string $sizes A source size value for use in a 'sizes' attribute.
-	 * @param array  $size  Image size. Accepts an array of width and height
-	 *                      values in pixels (in that order).
-	 * @return string A source size value for use in a content image 'sizes' attribute.
-	 */
-	function twentyseventeen_content_image_sizes_attr( $sizes, $size ) {
-		$width = $size[0];
-
-		740 <= $width && $sizes = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, 740px';
-
-		if ( is_active_sidebar( 'sidebar-1' ) || is_archive() || is_search() || is_home() || is_page() ) {
-			if ( ! ( is_page() && 'one-column' === get_theme_mod( 'page_options' ) ) ) {
-				767 <= $width && $sizes = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
-			}
-		}
-
-		return $sizes;
-	}
-	add_filter( 'wp_calculate_image_sizes', 'twentyseventeen_content_image_sizes_attr', 10 , 2 );
-
-	/**
-	 * Add custom image sizes attribute to enhance responsive image functionality
-	 * for post thumbnails
-	 *
-	 * @since Twenty Seventeen 1.0
-	 *
-	 * @param array $attr Attributes for the image markup.
-	 * @param int   $attachment Image attachment ID.
-	 * @param array $size Registered image size or flat array of height and width dimensions.
-	 * @return string A source size value for use in a post thumbnail 'sizes' attribute.
-	 */
-	function twentyseventeen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
-		if ( is_archive() || is_search() || is_home() ) {
-			$attr['sizes'] = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
-		} else {
-			$attr['sizes'] = '100vw';
-		}
-		return $attr;
-	}
-	add_filter( 'wp_get_attachment_image_attributes', 'twentyseventeen_post_thumbnail_sizes_attr', 10 , 3 );
-
-
-	/**
-	 * Implement the Custom Header feature.
-	 */
-	require get_parent_theme_file_path( '/inc/custom-header.php' );
-
-	/**
-	 * Custom template tags for this theme.
-	 */
-	require get_parent_theme_file_path( '/inc/template-tags.php' );
-
-	/**
-	 * Custom functions that act independently of the theme templates.
-	 */
-	require get_parent_theme_file_path( '/inc/extras.php' );
-
-	/**
-	 * Customizer additions.
-	 */
-	require get_parent_theme_file_path( '/inc/customizer.php' );
-
-	/**
-	 * SVG icons functions and filters.
-	 */
-	require get_parent_theme_file_path( '/inc/functions-icons.php' );
-
+	return;
 }
+
+if ( ! function_exists( 'twentyseventeen_setup' ) ) :
+/**
+ * Sets up theme defaults and registers support for various WordPress features.
+ *
+ * Note that this function is hooked into the after_setup_theme hook, which
+ * runs before the init hook. The init hook is too late for some features, such
+ * as indicating support for post thumbnails.
+ */
+function twentyseventeen_setup() {
+	/*
+	 * Make theme available for translation.
+	 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentyseventeen
+	 * If you're building a theme based on Twenty Seventeen, use a find and replace
+	 * to change 'twentyseventeen' to the name of your theme in all the template files.
+	 */
+	load_theme_textdomain( 'twentyseventeen' );
+
+	// Add default posts and comments RSS feed links to head.
+	add_theme_support( 'automatic-feed-links' );
+
+	/*
+	 * Let WordPress manage the document title.
+	 * By adding theme support, we declare that this theme does not use a
+	 * hard-coded <title> tag in the document head, and expect WordPress to
+	 * provide it for us.
+	 */
+	add_theme_support( 'title-tag' );
+
+	/*
+	 * Enable support for Post Thumbnails on posts and pages.
+	 *
+	 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
+	 */
+	add_theme_support( 'post-thumbnails' );
+
+	add_image_size( 'twentyseventeen-featured-image', 2000, 1200, true );
+
+	add_image_size( 'twentyseventeen-thumbnail-avatar', 100, 100, true );
+
+	// This theme uses wp_nav_menu() in two locations.
+	register_nav_menus( array(
+		'top'    => __( 'Top', 'twentyseventeen' ),
+		'social' => __( 'Social Links Menu', 'twentyseventeen' ),
+	) );
+
+	/*
+	 * Switch default core markup for search form, comment form, and comments
+	 * to output valid HTML5.
+	 */
+	add_theme_support( 'html5', array(
+		'comment-form',
+		'comment-list',
+		'gallery',
+		'caption',
+	) );
+
+	/*
+	 * Enable support for Post Formats.
+	 *
+	 * See: https://codex.wordpress.org/Post_Formats
+	 */
+	add_theme_support( 'post-formats', array(
+		'aside',
+		'image',
+		'video',
+		'quote',
+		'link',
+		'gallery',
+		'audio',
+	) );
+
+	// Add theme support for Custom Logo.
+	add_theme_support( 'custom-logo', array(
+		'width'       => 1000,
+		'height'      => 1000,
+		'flex-width'  => true,
+		'flex-height' => true,
+	) );
+}
+endif;
+add_action( 'after_setup_theme', 'twentyseventeen_setup' );
+
+/**
+ * Set the content width in pixels, based on the theme's design and stylesheet.
+ *
+ * Priority 0 to make it available to lower priority callbacks.
+ *
+ * @global int $content_width
+ */
+function twentyseventeen_content_width() {
+	$GLOBALS['content_width'] = apply_filters( 'twentyseventeen_content_width', 700 );
+}
+add_action( 'after_setup_theme', 'twentyseventeen_content_width', 0 );
+
+/**
+ * Register custom fonts
+ */
+function twentyseventeen_fonts_url() {
+	$fonts_url = '';
+
+	/**
+	 * Translators: If there are characters in your language that are not
+	 * supported by Libre Frankin, translate this to 'off'. Do not translate
+	 * into your own language.
+	 */
+	$libre_franklin = _x( 'on', 'libre_franklin font: on or off', 'twentyseventeen' );
+
+	if ( 'off' !== $libre_franklin ) {
+		$font_families = array();
+
+		$font_families[] = 'Libre Franklin:300,300i,400,400i,600,600i,800,800i';
+
+		$query_args = array(
+			'family' => urlencode( implode( '|', $font_families ) ),
+			'subset' => urlencode( 'latin,latin-ext' ),
+		);
+
+		$fonts_url = add_query_arg( $query_args, 'https://fonts.googleapis.com/css' );
+	}
+
+	return esc_url_raw( $fonts_url );
+}
+
+/**
+ * Register widget area.
+ *
+ * @link https://developer.wordpress.org/themes/functionality/sidebars/#registering-a-sidebar
+ */
+function twentyseventeen_widgets_init() {
+	register_sidebar( array(
+		'name'          => __( 'Sidebar', 'twentyseventeen' ),
+		'id'            => 'sidebar-1',
+		'description'   => '',
+		'before_widget' => '<section id="%1$s" class="widget %2$s">',
+		'after_widget'  => '</section>',
+		'before_title'  => '<h2 class="widget-title">',
+		'after_title'   => '</h2>',
+	) );
+
+	register_sidebar( array(
+		'name'          => __( 'Footer 1', 'twentyseventeen' ),
+		'id'            => 'sidebar-2',
+		'description'   => '',
+		'before_widget' => '<section id="%1$s" class="widget %2$s">',
+		'after_widget'  => '</section>',
+		'before_title'  => '<h2 class="widget-title">',
+		'after_title'   => '</h2>',
+	) );
+
+	register_sidebar( array(
+		'name'          => __( 'Footer 2', 'twentyseventeen' ),
+		'id'            => 'sidebar-3',
+		'description'   => '',
+		'before_widget' => '<section id="%1$s" class="widget %2$s">',
+		'after_widget'  => '</section>',
+		'before_title'  => '<h2 class="widget-title">',
+		'after_title'   => '</h2>',
+	) );
+}
+add_action( 'widgets_init', 'twentyseventeen_widgets_init' );
+
+if ( ! function_exists( 'twentyseventeen_excerpt_continue_reading' ) ) {
+/**
+ * Replaces the excerpt "more" text by a link
+ */
+function twentyseventeen_excerpt_continue_reading() {
+	return ' &hellip; <p class="link-more"><a href="' . esc_url( get_permalink() ) . '">' . sprintf( __( 'Continue reading %s', 'twentyseventeen' ), the_title( '<span class="screen-reader-text">"', '"</span>', false ) ) . '</a></p>';
+}
+}
+add_filter( 'excerpt_more', 'twentyseventeen_excerpt_continue_reading' );
+
+/**
+ * Handles JavaScript detection.
+ *
+ * Adds a `js` class to the root `<html>` element when JavaScript is detected.
+ *
+ * @since Twenty Seventeen 1.0
+ */
+function twentyseventeen_javascript_detection() {
+	echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>\n";
+}
+add_action( 'wp_head', 'twentyseventeen_javascript_detection', 0 );
+
+/**
+ * Enqueue scripts and styles.
+ */
+function twentyseventeen_scripts() {
+	// Add custom fonts, used in the main stylesheet.
+	wp_enqueue_style( 'twentyseventeen-fonts', twentyseventeen_fonts_url(), array(), null );
+
+	// Theme stylesheet.
+	wp_enqueue_style( 'twentyseventeen-style', get_stylesheet_uri() );
+
+	// Load the dark colorscheme.
+	if ( 'dark' === get_theme_mod( 'colorscheme', 'light' ) || is_customize_preview() ) {
+		wp_enqueue_style( 'twentyseventeen-colors-dark', get_theme_file_uri( '/assets/css/colors-dark.css' ), array( 'twentyseventeen-style' ), '20161006' );
+	}
+
+	// Load the Internet Explorer 8 specific stylesheet.
+	wp_enqueue_style( 'twentyseventeen-ie8', get_theme_file_uri( '/assets/css/ie8.css' ), array( 'twentyseventeen-style' ), '20160928' );
+	wp_style_add_data( 'twentyseventeen-ie8', 'conditional', 'lt IE 9' );
+
+	// Load the html5 shiv.
+	wp_enqueue_script( 'html5', get_theme_file_uri( '/assets/js/html5.js' ), array(), '3.7.3' );
+	wp_script_add_data( 'html5', 'conditional', 'lt IE 9' );
+
+	wp_enqueue_script( 'twentyseventeen-skip-link-focus-fix', get_theme_file_uri( '/assets/js/skip-link-focus-fix.js' ), array(), '20151215', true );
+
+	wp_enqueue_script( 'twentyseventeen-navigation', get_theme_file_uri( '/assets/js/navigation.js' ), array(), '20151215', true );
+
+	wp_localize_script( 'twentyseventeen-navigation', 'twentyseventeenScreenReaderText', array(
+		'expand'   => __( 'Expand child menu', 'twentyseventeen' ),
+		'collapse' => __( 'Collapse child menu', 'twentyseventeen' ),
+		'icon'     => twentyseventeen_get_svg( array( 'icon' => 'expand' ) ),
+	) );
+
+	wp_enqueue_script( 'twentyseventeen-global', get_theme_file_uri( '/assets/js/global.js' ), array( 'jquery' ), '20151215', true );
+
+	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
+		wp_enqueue_script( 'comment-reply' );
+	}
+
+	// Scroll effects (only loaded on front page).
+	if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) {
+		wp_enqueue_script( 'jquery-scrollto', get_theme_file_uri( '/assets/js/jquery.scrollTo.js' ), array( 'jquery' ), '20151030', true );
+	}
+}
+add_action( 'wp_enqueue_scripts', 'twentyseventeen_scripts' );
+
+/**
+ * Add custom image sizes attribute to enhance responsive image functionality
+ * for content images
+ *
+ * @since Twenty Seventeen 1.0
+ *
+ * @param string $sizes A source size value for use in a 'sizes' attribute.
+ * @param array  $size  Image size. Accepts an array of width and height
+ *                      values in pixels (in that order).
+ * @return string A source size value for use in a content image 'sizes' attribute.
+ */
+function twentyseventeen_content_image_sizes_attr( $sizes, $size ) {
+	$width = $size[0];
+
+	740 <= $width && $sizes = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, 740px';
+
+	if ( is_active_sidebar( 'sidebar-1' ) || is_archive() || is_search() || is_home() || is_page() ) {
+		if ( ! ( is_page() && 'one-column' === get_theme_mod( 'page_options' ) ) ) {
+			767 <= $width && $sizes = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
+		}
+	}
+
+	return $sizes;
+}
+add_filter( 'wp_calculate_image_sizes', 'twentyseventeen_content_image_sizes_attr', 10 , 2 );
+
+/**
+ * Add custom image sizes attribute to enhance responsive image functionality
+ * for post thumbnails
+ *
+ * @since Twenty Seventeen 1.0
+ *
+ * @param array $attr Attributes for the image markup.
+ * @param int   $attachment Image attachment ID.
+ * @param array $size Registered image size or flat array of height and width dimensions.
+ * @return string A source size value for use in a post thumbnail 'sizes' attribute.
+ */
+function twentyseventeen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
+	if ( is_archive() || is_search() || is_home() ) {
+		$attr['sizes'] = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
+	} else {
+		$attr['sizes'] = '100vw';
+	}
+	return $attr;
+}
+add_filter( 'wp_get_attachment_image_attributes', 'twentyseventeen_post_thumbnail_sizes_attr', 10 , 3 );
+
+/**
+ * Implement the Custom Header feature.
+ */
+require get_parent_theme_file_path( '/inc/custom-header.php' );
+
+/**
+ * Custom template tags for this theme.
+ */
+require get_parent_theme_file_path( '/inc/template-tags.php' );
+
+/**
+ * Custom functions that act independently of the theme templates.
+ */
+require get_parent_theme_file_path( '/inc/extras.php' );
+
+/**
+ * Customizer additions.
+ */
+require get_parent_theme_file_path( '/inc/customizer.php' );
+
+/**
+ * SVG icons functions and filters.
+ */
+require get_parent_theme_file_path( '/inc/functions-icons.php' );

--- a/functions.php
+++ b/functions.php
@@ -17,6 +17,7 @@ if ( version_compare( $GLOBALS['wp_version'], '4.7-alpha', '<' ) ) {
 	require get_template_directory() . '/inc/back-compat.php';
 
 } else {
+
 	/**
 	 * Twenty Seventeen functions and definitions
 	 *

--- a/functions.php
+++ b/functions.php
@@ -227,7 +227,7 @@ function twentyseventeen_colors_css_wrap() {
 		return;
 	}
 
-	require_once( 'color-patterns.php' );
+	require_once( 'inc/color-patterns.php' );
 	$hue = absint( get_theme_mod( 'colorscheme_hue', 250 ) );
 ?>
 	<style type="text/css" id="custom-theme-colors" <?php if ( is_customize_preview() ) { echo 'data-hue="' . $hue . '"'; } ?>>

--- a/functions.php
+++ b/functions.php
@@ -91,7 +91,7 @@ function twentyseventeen_setup() {
 	/*
 	 * This theme styles the visual editor to resemble the theme style,
 	 * specifically font, colors, and column width.
- 	*/
+ 	 */
 	add_editor_style( array( 'assets/css/editor-style.css', twentyseventeen_fonts_url() ) );
 }
 endif;

--- a/functions.php
+++ b/functions.php
@@ -9,320 +9,340 @@
  * @since 1.0
  */
 
-if ( ! function_exists( 'twentyseventeen_setup' ) ) :
 /**
- * Sets up theme defaults and registers support for various WordPress features.
- *
- * Note that this function is hooked into the after_setup_theme hook, which
- * runs before the init hook. The init hook is too late for some features, such
- * as indicating support for post thumbnails.
+ * Twenty Seventeen only works in WordPress 4.7 or later.
  */
-function twentyseventeen_setup() {
-	/*
-	 * Make theme available for translation.
-	 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentyseventeen
-	 * If you're building a theme based on Twenty Seventeen, use a find and replace
-	 * to change 'twentyseventeen' to the name of your theme in all the template files.
-	 */
-	load_theme_textdomain( 'twentyseventeen' );
+if ( version_compare( $GLOBALS['wp_version'], '4.7-alpha', '<' ) ) {
 
-	// Add default posts and comments RSS feed links to head.
-	add_theme_support( 'automatic-feed-links' );
+	require get_template_directory() . '/inc/back-compat.php';
 
-	/*
-	 * Let WordPress manage the document title.
-	 * By adding theme support, we declare that this theme does not use a
-	 * hard-coded <title> tag in the document head, and expect WordPress to
-	 * provide it for us.
-	 */
-	add_theme_support( 'title-tag' );
-
-	/*
-	 * Enable support for Post Thumbnails on posts and pages.
+} else {
+	/**
+	 * Twenty Seventeen functions and definitions
 	 *
-	 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
-	 */
-	add_theme_support( 'post-thumbnails' );
-
-	add_image_size( 'twentyseventeen-featured-image', 2000, 1200, true );
-
-	add_image_size( 'twentyseventeen-thumbnail-avatar', 100, 100, true );
-
-	// This theme uses wp_nav_menu() in two locations.
-	register_nav_menus( array(
-		'top'    => __( 'Top', 'twentyseventeen' ),
-		'social' => __( 'Social Links Menu', 'twentyseventeen' ),
-	) );
-
-	/*
-	 * Switch default core markup for search form, comment form, and comments
-	 * to output valid HTML5.
-	 */
-	add_theme_support( 'html5', array(
-		'comment-form',
-		'comment-list',
-		'gallery',
-		'caption',
-	) );
-
-	/*
-	 * Enable support for Post Formats.
+	 * @link https://developer.wordpress.org/themes/basics/theme-functions/
 	 *
-	 * See: https://codex.wordpress.org/Post_Formats
+	 * @package WordPress
+	 * @subpackage Twenty_Seventeen
+	 * @since 1.0
 	 */
-	add_theme_support( 'post-formats', array(
-		'aside',
-		'image',
-		'video',
-		'quote',
-		'link',
-		'gallery',
-		'audio',
-	) );
 
-	// Add theme support for Custom Logo.
-	add_theme_support( 'custom-logo', array(
-		'width'       => 1000,
-		'height'      => 1000,
-		'flex-width'  => true,
-		'flex-height' => true,
-	) );
-}
-endif;
-add_action( 'after_setup_theme', 'twentyseventeen_setup' );
+	if ( ! function_exists( 'twentyseventeen_setup' ) ) :
+	/**
+	 * Sets up theme defaults and registers support for various WordPress features.
+	 *
+	 * Note that this function is hooked into the after_setup_theme hook, which
+	 * runs before the init hook. The init hook is too late for some features, such
+	 * as indicating support for post thumbnails.
+	 */
+	function twentyseventeen_setup() {
+		/*
+		 * Make theme available for translation.
+		 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentyseventeen
+		 * If you're building a theme based on Twenty Seventeen, use a find and replace
+		 * to change 'twentyseventeen' to the name of your theme in all the template files.
+		 */
+		load_theme_textdomain( 'twentyseventeen' );
 
+		// Add default posts and comments RSS feed links to head.
+		add_theme_support( 'automatic-feed-links' );
 
-/**
- * Set the content width in pixels, based on the theme's design and stylesheet.
- *
- * Priority 0 to make it available to lower priority callbacks.
- *
- * @global int $content_width
- */
-function twentyseventeen_content_width() {
-	$GLOBALS['content_width'] = apply_filters( 'twentyseventeen_content_width', 700 );
-}
-add_action( 'after_setup_theme', 'twentyseventeen_content_width', 0 );
+		/*
+		 * Let WordPress manage the document title.
+		 * By adding theme support, we declare that this theme does not use a
+		 * hard-coded <title> tag in the document head, and expect WordPress to
+		 * provide it for us.
+		 */
+		add_theme_support( 'title-tag' );
 
+		/*
+		 * Enable support for Post Thumbnails on posts and pages.
+		 *
+		 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
+		 */
+		add_theme_support( 'post-thumbnails' );
 
-/**
- * Register custom fonts
- */
-function twentyseventeen_fonts_url() {
-	$fonts_url = '';
+		add_image_size( 'twentyseventeen-featured-image', 2000, 1200, true );
+
+		add_image_size( 'twentyseventeen-thumbnail-avatar', 100, 100, true );
+
+		// This theme uses wp_nav_menu() in two locations.
+		register_nav_menus( array(
+			'top'    => __( 'Top', 'twentyseventeen' ),
+			'social' => __( 'Social Links Menu', 'twentyseventeen' ),
+		) );
+
+		/*
+		 * Switch default core markup for search form, comment form, and comments
+		 * to output valid HTML5.
+		 */
+		add_theme_support( 'html5', array(
+			'comment-form',
+			'comment-list',
+			'gallery',
+			'caption',
+		) );
+
+		/*
+		 * Enable support for Post Formats.
+		 *
+		 * See: https://codex.wordpress.org/Post_Formats
+		 */
+		add_theme_support( 'post-formats', array(
+			'aside',
+			'image',
+			'video',
+			'quote',
+			'link',
+			'gallery',
+			'audio',
+		) );
+
+		// Add theme support for Custom Logo.
+		add_theme_support( 'custom-logo', array(
+			'width'       => 1000,
+			'height'      => 1000,
+			'flex-width'  => true,
+			'flex-height' => true,
+		) );
+	}
+	endif;
+	add_action( 'after_setup_theme', 'twentyseventeen_setup' );
+
 
 	/**
-	 * Translators: If there are characters in your language that are not
-	 * supported by Libre Frankin, translate this to 'off'. Do not translate
-	 * into your own language.
+	 * Set the content width in pixels, based on the theme's design and stylesheet.
+	 *
+	 * Priority 0 to make it available to lower priority callbacks.
+	 *
+	 * @global int $content_width
 	 */
-	$libre_franklin = _x( 'on', 'libre_franklin font: on or off', 'twentyseventeen' );
+	function twentyseventeen_content_width() {
+		$GLOBALS['content_width'] = apply_filters( 'twentyseventeen_content_width', 700 );
+	}
+	add_action( 'after_setup_theme', 'twentyseventeen_content_width', 0 );
 
-	if ( 'off' !== $libre_franklin ) {
-		$font_families = array();
 
-		$font_families[] = 'Libre Franklin:300,300i,400,400i,600,600i,800,800i';
+	/**
+	 * Register custom fonts
+	 */
+	function twentyseventeen_fonts_url() {
+		$fonts_url = '';
 
-		$query_args = array(
-			'family' => urlencode( implode( '|', $font_families ) ),
-			'subset' => urlencode( 'latin,latin-ext' ),
-		);
+		/**
+		 * Translators: If there are characters in your language that are not
+		 * supported by Libre Frankin, translate this to 'off'. Do not translate
+		 * into your own language.
+		 */
+		$libre_franklin = _x( 'on', 'libre_franklin font: on or off', 'twentyseventeen' );
 
-		$fonts_url = add_query_arg( $query_args, 'https://fonts.googleapis.com/css' );
+		if ( 'off' !== $libre_franklin ) {
+			$font_families = array();
+
+			$font_families[] = 'Libre Franklin:300,300i,400,400i,600,600i,800,800i';
+
+			$query_args = array(
+				'family' => urlencode( implode( '|', $font_families ) ),
+				'subset' => urlencode( 'latin,latin-ext' ),
+			);
+
+			$fonts_url = add_query_arg( $query_args, 'https://fonts.googleapis.com/css' );
+		}
+
+		return esc_url_raw( $fonts_url );
 	}
 
-	return esc_url_raw( $fonts_url );
-}
+	/**
+	 * Register widget area.
+	 *
+	 * @link https://developer.wordpress.org/themes/functionality/sidebars/#registering-a-sidebar
+	 */
+	function twentyseventeen_widgets_init() {
+		register_sidebar( array(
+			'name'          => __( 'Sidebar', 'twentyseventeen' ),
+			'id'            => 'sidebar-1',
+			'description'   => '',
+			'before_widget' => '<section id="%1$s" class="widget %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h2 class="widget-title">',
+			'after_title'   => '</h2>',
+		) );
 
-/**
- * Register widget area.
- *
- * @link https://developer.wordpress.org/themes/functionality/sidebars/#registering-a-sidebar
- */
-function twentyseventeen_widgets_init() {
-	register_sidebar( array(
-		'name'          => __( 'Sidebar', 'twentyseventeen' ),
-		'id'            => 'sidebar-1',
-		'description'   => '',
-		'before_widget' => '<section id="%1$s" class="widget %2$s">',
-		'after_widget'  => '</section>',
-		'before_title'  => '<h2 class="widget-title">',
-		'after_title'   => '</h2>',
-	) );
+		register_sidebar( array(
+			'name'          => __( 'Footer 1', 'twentyseventeen' ),
+			'id'            => 'sidebar-2',
+			'description'   => '',
+			'before_widget' => '<section id="%1$s" class="widget %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h2 class="widget-title">',
+			'after_title'   => '</h2>',
+		) );
 
-	register_sidebar( array(
-		'name'          => __( 'Footer 1', 'twentyseventeen' ),
-		'id'            => 'sidebar-2',
-		'description'   => '',
-		'before_widget' => '<section id="%1$s" class="widget %2$s">',
-		'after_widget'  => '</section>',
-		'before_title'  => '<h2 class="widget-title">',
-		'after_title'   => '</h2>',
-	) );
-
-	register_sidebar( array(
-		'name'          => __( 'Footer 2', 'twentyseventeen' ),
-		'id'            => 'sidebar-3',
-		'description'   => '',
-		'before_widget' => '<section id="%1$s" class="widget %2$s">',
-		'after_widget'  => '</section>',
-		'before_title'  => '<h2 class="widget-title">',
-		'after_title'   => '</h2>',
-	) );
-}
-add_action( 'widgets_init', 'twentyseventeen_widgets_init' );
-
-
-/**
- * Output Custom Logo.
- */
-function twentyseventeen_the_custom_logo() {
-	if ( function_exists( 'the_custom_logo' ) ) {
-		the_custom_logo();
+		register_sidebar( array(
+			'name'          => __( 'Footer 2', 'twentyseventeen' ),
+			'id'            => 'sidebar-3',
+			'description'   => '',
+			'before_widget' => '<section id="%1$s" class="widget %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h2 class="widget-title">',
+			'after_title'   => '</h2>',
+		) );
 	}
-}
+	add_action( 'widgets_init', 'twentyseventeen_widgets_init' );
 
 
-if ( ! function_exists( 'twentyseventeen_excerpt_continue_reading' ) ) {
-/**
- * Replaces the excerpt "more" text by a link
- */
-function twentyseventeen_excerpt_continue_reading() {
-	return ' &hellip; <p class="link-more"><a href="' . esc_url( get_permalink() ) . '">' . sprintf( __( 'Continue reading %s', 'twentyseventeen' ), the_title( '<span class="screen-reader-text">"', '"</span>', false ) ) . '</a></p>';
-}
-}
-add_filter( 'excerpt_more', 'twentyseventeen_excerpt_continue_reading' );
-
-
-/**
- * Handles JavaScript detection.
- *
- * Adds a `js` class to the root `<html>` element when JavaScript is detected.
- *
- * @since Twenty Seventeen 1.0
- */
-function twentyseventeen_javascript_detection() {
-	echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>\n";
-}
-add_action( 'wp_head', 'twentyseventeen_javascript_detection', 0 );
-
-/**
- * Enqueue scripts and styles.
- */
-function twentyseventeen_scripts() {
-	// Add custom fonts, used in the main stylesheet.
-	wp_enqueue_style( 'twentyseventeen-fonts', twentyseventeen_fonts_url(), array(), null );
-
-	// Theme stylesheet.
-	wp_enqueue_style( 'twentyseventeen-style', get_stylesheet_uri() );
-
-	// Load the dark colorscheme.
-	if ( 'dark' === get_theme_mod( 'colorscheme', 'light' ) || is_customize_preview() ) {
-		wp_enqueue_style( 'twentyseventeen-colors-dark', get_template_directory_uri() . '/assets/css/colors-dark.css', array( 'twentyseventeen-style' ), '20161006' );
-	}
-
-	// Load the Internet Explorer 8 specific stylesheet.
-	wp_enqueue_style( 'twentyseventeen-ie8', get_template_directory_uri() . '/assets/css/ie8.css', array( 'twentyseventeen-style' ), '20160928' );
-	wp_style_add_data( 'twentyseventeen-ie8', 'conditional', 'lt IE 9' );
-
-	// Load the html5 shiv.
-	wp_enqueue_script( 'html5', get_template_directory_uri() . '/assets/js/html5.js', array(), '3.7.3' );
-	wp_script_add_data( 'html5', 'conditional', 'lt IE 9' );
-
-	wp_enqueue_script( 'twentyseventeen-skip-link-focus-fix', get_template_directory_uri() . '/assets/js/skip-link-focus-fix.js', array(), '20151215', true );
-
-	wp_enqueue_script( 'twentyseventeen-navigation', get_template_directory_uri() . '/assets/js/navigation.js', array(), '20151215', true );
-
-	wp_localize_script( 'twentyseventeen-navigation', 'twentyseventeenScreenReaderText', array(
-		'expand'   => __( 'Expand child menu', 'twentyseventeen' ),
-		'collapse' => __( 'Collapse child menu', 'twentyseventeen' ),
-		'icon'     => twentyseventeen_get_svg( array( 'icon' => 'expand' ) ),
-	) );
-
-	wp_enqueue_script( 'twentyseventeen-global', get_template_directory_uri() . '/assets/js/global.js', array( 'jquery' ), '20151215', true );
-
-	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
-		wp_enqueue_script( 'comment-reply' );
-	}
-
-	// Scroll effects (only loaded on front page).
-	if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) {
-		wp_enqueue_script( 'jquery-scrollto', get_template_directory_uri() . '/assets/js/jquery.scrollTo.js', array( 'jquery' ), '20151030', true );
-	}
-
-}
-add_action( 'wp_enqueue_scripts', 'twentyseventeen_scripts' );
-
-
-/**
- * Add custom image sizes attribute to enhance responsive image functionality
- * for content images
- *
- * @since Twenty Seventeen 1.0
- *
- * @param string $sizes A source size value for use in a 'sizes' attribute.
- * @param array  $size  Image size. Accepts an array of width and height
- *                      values in pixels (in that order).
- * @return string A source size value for use in a content image 'sizes' attribute.
- */
-function twentyseventeen_content_image_sizes_attr( $sizes, $size ) {
-	$width = $size[0];
-
-	740 <= $width && $sizes = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, 740px';
-
-	if ( is_active_sidebar( 'sidebar-1' ) || is_archive() || is_search() || is_home() || is_page() ) {
-		if ( ! ( is_page() && 'one-column' === get_theme_mod( 'page_options' ) ) ) {
-			767 <= $width && $sizes = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
+	/**
+	 * Output Custom Logo.
+	 */
+	function twentyseventeen_the_custom_logo() {
+		if ( function_exists( 'the_custom_logo' ) ) {
+			the_custom_logo();
 		}
 	}
 
-	return $sizes;
-}
-add_filter( 'wp_calculate_image_sizes', 'twentyseventeen_content_image_sizes_attr', 10 , 2 );
 
-/**
- * Add custom image sizes attribute to enhance responsive image functionality
- * for post thumbnails
- *
- * @since Twenty Seventeen 1.0
- *
- * @param array $attr Attributes for the image markup.
- * @param int   $attachment Image attachment ID.
- * @param array $size Registered image size or flat array of height and width dimensions.
- * @return string A source size value for use in a post thumbnail 'sizes' attribute.
- */
-function twentyseventeen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
-	if ( is_archive() || is_search() || is_home() ) {
-		$attr['sizes'] = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
-	} else {
-		$attr['sizes'] = '100vw';
+	if ( ! function_exists( 'twentyseventeen_excerpt_continue_reading' ) ) {
+	/**
+	 * Replaces the excerpt "more" text by a link
+	 */
+	function twentyseventeen_excerpt_continue_reading() {
+		return ' &hellip; <p class="link-more"><a href="' . esc_url( get_permalink() ) . '">' . sprintf( __( 'Continue reading %s', 'twentyseventeen' ), the_title( '<span class="screen-reader-text">"', '"</span>', false ) ) . '</a></p>';
 	}
-	return $attr;
+	}
+	add_filter( 'excerpt_more', 'twentyseventeen_excerpt_continue_reading' );
+
+
+	/**
+	 * Handles JavaScript detection.
+	 *
+	 * Adds a `js` class to the root `<html>` element when JavaScript is detected.
+	 *
+	 * @since Twenty Seventeen 1.0
+	 */
+	function twentyseventeen_javascript_detection() {
+		echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>\n";
+	}
+	add_action( 'wp_head', 'twentyseventeen_javascript_detection', 0 );
+
+	/**
+	 * Enqueue scripts and styles.
+	 */
+	function twentyseventeen_scripts() {
+		// Add custom fonts, used in the main stylesheet.
+		wp_enqueue_style( 'twentyseventeen-fonts', twentyseventeen_fonts_url(), array(), null );
+
+		// Theme stylesheet.
+		wp_enqueue_style( 'twentyseventeen-style', get_stylesheet_uri() );
+
+		// Load the dark colorscheme.
+		if ( 'dark' === get_theme_mod( 'colorscheme', 'light' ) || is_customize_preview() ) {
+			wp_enqueue_style( 'twentyseventeen-colors-dark', get_theme_file_uri( '/assets/css/colors-dark.css' ), array( 'twentyseventeen-style' ), '20161006' );
+		}
+
+		// Load the Internet Explorer 8 specific stylesheet.
+		wp_enqueue_style( 'twentyseventeen-ie8', get_theme_file_uri( '/assets/css/ie8.css' ), array( 'twentyseventeen-style' ), '20160928' );
+		wp_style_add_data( 'twentyseventeen-ie8', 'conditional', 'lt IE 9' );
+
+		// Load the html5 shiv.
+		wp_enqueue_script( 'html5', get_theme_file_uri( '/assets/js/html5.js' ), array(), '3.7.3' );
+		wp_script_add_data( 'html5', 'conditional', 'lt IE 9' );
+
+		wp_enqueue_script( 'twentyseventeen-skip-link-focus-fix', get_theme_file_uri( '/assets/js/skip-link-focus-fix.js' ), array(), '20151215', true );
+
+		wp_enqueue_script( 'twentyseventeen-navigation', get_theme_file_uri( '/assets/js/navigation.js' ), array(), '20151215', true );
+
+		wp_localize_script( 'twentyseventeen-navigation', 'twentyseventeenScreenReaderText', array(
+			'expand'   => __( 'Expand child menu', 'twentyseventeen' ),
+			'collapse' => __( 'Collapse child menu', 'twentyseventeen' ),
+			'icon'     => twentyseventeen_get_svg( array( 'icon' => 'expand' ) ),
+		) );
+
+		wp_enqueue_script( 'twentyseventeen-global', get_theme_file_uri( '/assets/js/global.js' ), array( 'jquery' ), '20151215', true );
+
+		if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
+			wp_enqueue_script( 'comment-reply' );
+		}
+
+		// Scroll effects (only loaded on front page).
+		if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) {
+			wp_enqueue_script( 'jquery-scrollto', get_theme_file_uri( '/assets/js/jquery.scrollTo.js' ), array( 'jquery' ), '20151030', true );
+		}
+
+	}
+	add_action( 'wp_enqueue_scripts', 'twentyseventeen_scripts' );
+
+
+	/**
+	 * Add custom image sizes attribute to enhance responsive image functionality
+	 * for content images
+	 *
+	 * @since Twenty Seventeen 1.0
+	 *
+	 * @param string $sizes A source size value for use in a 'sizes' attribute.
+	 * @param array  $size  Image size. Accepts an array of width and height
+	 *                      values in pixels (in that order).
+	 * @return string A source size value for use in a content image 'sizes' attribute.
+	 */
+	function twentyseventeen_content_image_sizes_attr( $sizes, $size ) {
+		$width = $size[0];
+
+		740 <= $width && $sizes = '(max-width: 706px) 89vw, (max-width: 767px) 82vw, 740px';
+
+		if ( is_active_sidebar( 'sidebar-1' ) || is_archive() || is_search() || is_home() || is_page() ) {
+			if ( ! ( is_page() && 'one-column' === get_theme_mod( 'page_options' ) ) ) {
+				767 <= $width && $sizes = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
+			}
+		}
+
+		return $sizes;
+	}
+	add_filter( 'wp_calculate_image_sizes', 'twentyseventeen_content_image_sizes_attr', 10 , 2 );
+
+	/**
+	 * Add custom image sizes attribute to enhance responsive image functionality
+	 * for post thumbnails
+	 *
+	 * @since Twenty Seventeen 1.0
+	 *
+	 * @param array $attr Attributes for the image markup.
+	 * @param int   $attachment Image attachment ID.
+	 * @param array $size Registered image size or flat array of height and width dimensions.
+	 * @return string A source size value for use in a post thumbnail 'sizes' attribute.
+	 */
+	function twentyseventeen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
+		if ( is_archive() || is_search() || is_home() ) {
+			$attr['sizes'] = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
+		} else {
+			$attr['sizes'] = '100vw';
+		}
+		return $attr;
+	}
+	add_filter( 'wp_get_attachment_image_attributes', 'twentyseventeen_post_thumbnail_sizes_attr', 10 , 3 );
+
+
+	/**
+	 * Implement the Custom Header feature.
+	 */
+	require get_parent_theme_file_path( '/inc/custom-header.php' );
+
+	/**
+	 * Custom template tags for this theme.
+	 */
+	require get_parent_theme_file_path( '/inc/template-tags.php' );
+
+	/**
+	 * Custom functions that act independently of the theme templates.
+	 */
+	require get_parent_theme_file_path( '/inc/extras.php' );
+
+	/**
+	 * Customizer additions.
+	 */
+	require get_parent_theme_file_path( '/inc/customizer.php' );
+
+	/**
+	 * SVG icons functions and filters.
+	 */
+	require get_parent_theme_file_path( '/inc/functions-icons.php' );
+
 }
-add_filter( 'wp_get_attachment_image_attributes', 'twentyseventeen_post_thumbnail_sizes_attr', 10 , 3 );
-
-
-/**
- * Implement the Custom Header feature.
- */
-require get_template_directory() . '/inc/custom-header.php';
-
-/**
- * Custom template tags for this theme.
- */
-require get_template_directory() . '/inc/template-tags.php';
-
-/**
- * Custom functions that act independently of the theme templates.
- */
-require get_template_directory() . '/inc/extras.php';
-
-/**
- * Customizer additions.
- */
-require get_template_directory() . '/inc/customizer.php';
-
-/**
- * SVG icons functions and filters.
- */
-require get_template_directory() . '/inc/functions-icons.php';

--- a/functions.php
+++ b/functions.php
@@ -238,7 +238,7 @@ function twentyseventeen_colors_css_wrap() {
 		<?php echo twentyseventeen_custom_colors_css(); ?>
 	</style>
 <?php }
-add_action( 'wp_head', 'twentyseventeen_colors_css_wrap' );
+//add_action( 'wp_head', 'twentyseventeen_colors_css_wrap' );
 
 /**
  * Enqueue scripts and styles.

--- a/functions.php
+++ b/functions.php
@@ -237,7 +237,7 @@ function twentyseventeen_colors_css_wrap() {
 		<?php echo twentyseventeen_custom_colors_css(); ?>
 	</style>
 <?php }
-//add_action( 'wp_head', 'twentyseventeen_colors_css_wrap' );
+add_action( 'wp_head', 'twentyseventeen_colors_css_wrap' );
 
 /**
  * Enqueue scripts and styles.

--- a/functions.php
+++ b/functions.php
@@ -90,9 +90,8 @@ function twentyseventeen_setup() {
 
 	// Add theme support for Custom Logo.
 	add_theme_support( 'custom-logo', array(
-		'width'       => 1000,
-		'height'      => 1000,
-		'flex-width'  => true,
+		'width'       => 250,
+		'height'      => 250,
 		'flex-height' => true,
 	) );
 
@@ -238,7 +237,7 @@ function twentyseventeen_colors_css_wrap() {
 		<?php echo twentyseventeen_custom_colors_css(); ?>
 	</style>
 <?php }
-//add_action( 'wp_head', 'twentyseventeen_colors_css_wrap' );
+add_action( 'wp_head', 'twentyseventeen_colors_css_wrap' );
 
 /**
  * Enqueue scripts and styles.

--- a/functions.php
+++ b/functions.php
@@ -237,7 +237,7 @@ function twentyseventeen_colors_css_wrap() {
 		<?php echo twentyseventeen_custom_colors_css(); ?>
 	</style>
 <?php }
-add_action( 'wp_head', 'twentyseventeen_colors_css_wrap' );
+//add_action( 'wp_head', 'twentyseventeen_colors_css_wrap' );
 
 /**
  * Enqueue scripts and styles.

--- a/functions.php
+++ b/functions.php
@@ -323,9 +323,7 @@ add_filter( 'wp_calculate_image_sizes', 'twentyseventeen_content_image_sizes_att
  * @return string A source size value for use in a post thumbnail 'sizes' attribute.
  */
 function twentyseventeen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
-	if ( 'custom-logo') {
-		$attr['sizes'] = '(max-width: 767px) 100vw, 700px';
-	} else if ( is_archive() || is_search() || is_home() ) {
+	if ( is_archive() || is_search() || is_home() ) {
 		$attr['sizes'] = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
 	} else {
 		$attr['sizes'] = '100vw';

--- a/functions.php
+++ b/functions.php
@@ -234,7 +234,7 @@ function twentyseventeen_colors_css_wrap() {
 		<?php echo twentyseventeen_custom_colors_css(); ?>
 	</style>
 <?php }
-add_action( 'wp_head', 'twentyseventeen_colors_css_wrap' );
+//add_action( 'wp_head', 'twentyseventeen_colors_css_wrap' );
 
 /**
  * Enqueue scripts and styles.

--- a/functions.php
+++ b/functions.php
@@ -92,7 +92,7 @@ function twentyseventeen_setup() {
 	add_theme_support( 'custom-logo', array(
 		'width'       => 250,
 		'height'      => 250,
-		'flex-height' => true,
+		'flex-width' => true,
 	) );
 
 	/*
@@ -323,7 +323,9 @@ add_filter( 'wp_calculate_image_sizes', 'twentyseventeen_content_image_sizes_att
  * @return string A source size value for use in a post thumbnail 'sizes' attribute.
  */
 function twentyseventeen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
-	if ( is_archive() || is_search() || is_home() ) {
+	if ( 'custom-logo') {
+		$attr['sizes'] = '(max-width: 767px) 100vw, 700px';
+	} else if ( is_archive() || is_search() || is_home() ) {
 		$attr['sizes'] = '(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px';
 	} else {
 		$attr['sizes'] = '100vw';

--- a/functions.php
+++ b/functions.php
@@ -82,9 +82,8 @@ function twentyseventeen_setup() {
 
 	// Add theme support for Custom Logo.
 	add_theme_support( 'custom-logo', array(
-		'width'       => 1000,
-		'height'      => 1000,
-		'flex-width'  => true,
+		'width'       => 250,
+		'height'      => 250,
 		'flex-height' => true,
 	) );
 }
@@ -234,7 +233,7 @@ function twentyseventeen_colors_css_wrap() {
 		<?php echo twentyseventeen_custom_colors_css(); ?>
 	</style>
 <?php }
-//add_action( 'wp_head', 'twentyseventeen_colors_css_wrap' );
+add_action( 'wp_head', 'twentyseventeen_colors_css_wrap' );
 
 /**
  * Enqueue scripts and styles.

--- a/inc/back-compat.php
+++ b/inc/back-compat.php
@@ -10,6 +10,7 @@
  * @subpackage Twenty_Seventeen
  * @since Twenty Seventeen 1.0
  */
+
 /**
  * Prevent switching to Twenty Seventeen on old versions of WordPress.
  *
@@ -23,6 +24,7 @@ function twentyseventeen_switch_theme() {
 	add_action( 'admin_notices', 'twentyseventeen_upgrade_notice' );
 }
 add_action( 'after_switch_theme', 'twentyseventeen_switch_theme' );
+
 /**
  * Adds a message for unsuccessful theme switch.
  *
@@ -37,6 +39,7 @@ function twentyseventeen_upgrade_notice() {
 	$message = sprintf( __( 'Twenty Seventeen requires at least WordPress version 4.7. You are running version %s. Please upgrade and try again.', 'twentyseventeen' ), $GLOBALS['wp_version'] );
 	printf( '<div class="error"><p>%s</p></div>', $message );
 }
+
 /**
  * Prevents the Customizer from being loaded on WordPress versions prior to 4.7.
  *
@@ -50,6 +53,7 @@ function twentyseventeen_customize() {
 	) );
 }
 add_action( 'load-customize.php', 'twentyseventeen_customize' );
+
 /**
  * Prevents the Theme Preview from being loaded on WordPress versions prior to 4.7.
  *

--- a/inc/back-compat.php
+++ b/inc/back-compat.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Twenty Seventeen back compat functionality
+ *
+ * Prevents Twenty Seventeen from running on WordPress versions prior to 4.7,
+ * since this theme is not meant to be backward compatible beyond that and
+ * relies on many newer functions and markup changes introduced in 4.7.
+ *
+ * @package WordPress
+ * @subpackage Twenty_Seventeen
+ * @since Twenty Seventeen 1.0
+ */
+/**
+ * Prevent switching to Twenty Seventeen on old versions of WordPress.
+ *
+ * Switches to the default theme.
+ *
+ * @since Twenty Seventeen 1.0
+ */
+function twentyseventeen_switch_theme() {
+	switch_theme( WP_DEFAULT_THEME, WP_DEFAULT_THEME );
+	unset( $_GET['activated'] );
+	add_action( 'admin_notices', 'twentyseventeen_upgrade_notice' );
+}
+add_action( 'after_switch_theme', 'twentyseventeen_switch_theme' );
+/**
+ * Adds a message for unsuccessful theme switch.
+ *
+ * Prints an update nag after an unsuccessful attempt to switch to
+ * Twenty Seventeen on WordPress versions prior to 4.7.
+ *
+ * @since Twenty Seventeen 1.0
+ *
+ * @global string $wp_version WordPress version.
+ */
+function twentyseventeen_upgrade_notice() {
+	$message = sprintf( __( 'Twenty Seventeen requires at least WordPress version 4.7. You are running version %s. Please upgrade and try again.', 'twentyseventeen' ), $GLOBALS['wp_version'] );
+	printf( '<div class="error"><p>%s</p></div>', $message );
+}
+/**
+ * Prevents the Customizer from being loaded on WordPress versions prior to 4.7.
+ *
+ * @since Twenty Seventeen 1.0
+ *
+ * @global string $wp_version WordPress version.
+ */
+function twentyseventeen_customize() {
+	wp_die( sprintf( __( 'Twenty Seventeen requires at least WordPress version 4.7. You are running version %s. Please upgrade and try again.', 'twentyseventeen' ), $GLOBALS['wp_version'] ), '', array(
+		'back_link' => true,
+	) );
+}
+add_action( 'load-customize.php', 'twentyseventeen_customize' );
+/**
+ * Prevents the Theme Preview from being loaded on WordPress versions prior to 4.7.
+ *
+ * @since Twenty Seventeen 1.0
+ *
+ * @global string $wp_version WordPress version.
+ */
+function twentyseventeen_preview() {
+	if ( isset( $_GET['preview'] ) ) {
+		wp_die( sprintf( __( 'Twenty Seventeen requires at least WordPress version 4.7. You are running version %s. Please upgrade and try again.', 'twentyseventeen' ), $GLOBALS['wp_version'] ) );
+	}
+}
+add_action( 'template_redirect', 'twentyseventeen_preview' );

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -16,7 +16,7 @@
  */
 function twentyseventeen_custom_header_setup() {
 	add_theme_support( 'custom-header', apply_filters( 'twentyseventeen_custom_header_args', array(
-		'default-image'      => get_template_directory_uri() . '/assets/images/header.jpg',
+		'default-image'      => get_parent_theme_file_uri( '/assets/images/header.jpg' ),
 		'default-text-color' => '222222',
 		'width'              => 2000,
 		'height'             => 1200,

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -61,6 +61,7 @@ function twentyseventeen_header_style() {
 			position: absolute;
 			clip: rect(1px, 1px, 1px, 1px);
 		}
+
 	<?php
 		// If the user has set a custom color for the text use that.
 		else :

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -207,7 +207,7 @@ function twentyseventeen_is_page() {
  * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
  */
 function twentyseventeen_customize_preview_js() {
-	wp_enqueue_script( 'twentyseventeen-customizer', get_template_directory_uri() . '/assets/js/customizer.js', array( 'customize-preview' ), '20151215', true );
+	wp_enqueue_script( 'twentyseventeen-customizer', get_theme_file_uri( '/assets/js/customizer.js' ), array( 'customize-preview' ), '20151215', true );
 }
 add_action( 'customize_preview_init', 'twentyseventeen_customize_preview_js' );
 
@@ -215,7 +215,7 @@ add_action( 'customize_preview_init', 'twentyseventeen_customize_preview_js' );
  * Some extra JavaScript to improve the user experience in the Customizer for this theme.
  */
 function twentyseventeen_panels_js() {
-	wp_enqueue_script( 'twentyseventeen-panel-customizer', get_template_directory_uri() . '/assets/js/panel-customizer.js', array(), '20151116', true );
+	wp_enqueue_script( 'twentyseventeen-panel-customizer', get_theme_file_uri( '/assets/js/panel-customizer.js' ), array(), '20151116', true );
 }
 add_action( 'customize_controls_enqueue_scripts', 'twentyseventeen_panels_js' );
 

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -15,7 +15,7 @@
 function twentyseventeen_customize_register( $wp_customize ) {
 	$wp_customize->get_setting( 'blogname' )->transport         = 'postMessage';
 	$wp_customize->get_setting( 'blogdescription' )->transport  = 'postMessage';
-	$wp_customize->get_setting( 'header_textcolor' )->transport = 'postMessage';
+	$wp_customize->get_setting( 'header_textcolor' )->transport = 'refresh';
 
 	/**
 	 * Custom colors.

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -15,7 +15,7 @@
 function twentyseventeen_customize_register( $wp_customize ) {
 	$wp_customize->get_setting( 'blogname' )->transport         = 'postMessage';
 	$wp_customize->get_setting( 'blogdescription' )->transport  = 'postMessage';
-	$wp_customize->get_setting( 'header_textcolor' )->transport = 'refresh';
+	$wp_customize->get_setting( 'header_textcolor' )->transport = 'postMessage';
 
 	/**
 	 * Custom colors.

--- a/inc/functions-icons.php
+++ b/inc/functions-icons.php
@@ -13,7 +13,7 @@
 function twentyseventeen_include_svg_icons() {
 
 	// Define SVG sprite file.
-	$svg_icons = get_template_directory() . '/assets/images/svg-icons.svg';
+	$svg_icons = get_parent_theme_file_path( '/assets/images/svg-icons.svg' );
 
 	// If it exists, include it.
 	if ( file_exists( $svg_icons ) ) {
@@ -87,7 +87,7 @@ function twentyseventeen_get_svg( $args = array() ) {
 
 	// Use absolute path in the Customizer so that icons show up in there.
 	if ( is_customize_preview() ) {
-		$svg .= '<use xlink:href="' . get_template_directory_uri() . '/assets/images/svg-icons.svg' . '#icon-' . esc_html( $args['icon'] ) . '"></use>';
+		$svg .= '<use xlink:href="' . get_parent_theme_file_uri( '/assets/images/svg-icons.svg' ) . '#icon-' . esc_html( $args['icon'] ) . '"></use>';
 	} else {
 		$svg .= '<use xlink:href="#icon-' . esc_html( $args['icon'] ) . '"></use>';
 	}

--- a/inc/functions-icons.php
+++ b/inc/functions-icons.php
@@ -87,7 +87,7 @@ function twentyseventeen_get_svg( $args = array() ) {
 
 	// Use absolute path in the Customizer so that icons show up in there.
 	if ( is_customize_preview() ) {
-		$svg .= '<use xlink:href="' . get_parent_theme_file_uri( '/assets/images/svg-icons.svg' ) . '#icon-' . esc_html( $args['icon'] ) . '"></use>';
+		$svg .= '<use xlink:href="' . get_parent_theme_file_uri( '/assets/images/svg-icons.svg#icon-' . esc_html( $args['icon'] ) ) . '"></use>';
 	} else {
 		$svg .= '<use xlink:href="#icon-' . esc_html( $args['icon'] ) . '"></use>';
 	}

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -53,6 +53,11 @@ function twentyseventeen_body_classes( $classes ) {
 		}
 	}
 
+	// Add class if the site title and tagline is hidden.
+	if ( 'blank' === get_header_textcolor() ) {
+		$classes[] = 'title-tagline-hidden';
+	}
+
 	// Get the colorschme or the default if there isn't one.
 	$colors = twentyseventeen_sanitize_colorscheme( get_theme_mod( 'colorscheme', 'light' ) );
 	$classes[] = 'colors-' . $colors;

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -96,8 +96,8 @@ function twentyseventeen_edit_link() {
 	$link = edit_post_link(
 		sprintf(
 			/* translators: %s: Name of current post */
-			__( 'Edit %s', 'twentyseventeen' ),
-			the_title( '<span class="screen-reader-text">"', '"</span>', false )
+			__( 'Edit <span class="screen-reader-text">"%s"</span>', 'twentyseventeen' ),
+			the_title( '', '', false )
 		),
 		'<span class="edit-link">',
 		'</span>'

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -96,8 +96,8 @@ function twentyseventeen_edit_link() {
 	$link = edit_post_link(
 		sprintf(
 			/* translators: %s: Name of current post */
-			__( 'Edit <span class="screen-reader-text">"%s"</span>', 'twentyseventeen' ),
-			the_title( '', '', false )
+			__( 'Edit<span class="screen-reader-text"> "%s"</span>', 'twentyseventeen' ),
+			get_the_title()
 		),
 		'<span class="edit-link">',
 		'</span>'

--- a/rtl.css
+++ b/rtl.css
@@ -64,9 +64,9 @@ input[type="checkbox"] {
 
 /* Site Branding */
 
-body:not(.title-tagline-hidden) .custom-logo-link {
-	margin-left: 1em;
-	margin-right: 0;
+.custom-logo-link {
+	padding-left: 1em;
+	padding-right: 0;
 }
 
 /* Main Navigation */
@@ -261,6 +261,15 @@ body:not(.title-tagline-hidden) .custom-logo-link {
 	.error404 #primary {
 		float: none;
 	}
+
+	/* Branding */
+
+	.custom-logo-link {
+		padding-left: 2em;
+		padding-right: 0;
+	}
+
+	/* Navigation */
 
 	.main-navigation ul ul {
 		padding-right: 0;

--- a/rtl.css
+++ b/rtl.css
@@ -62,6 +62,13 @@ input[type="checkbox"] {
 	right: -10000px;
 }
 
+/* Site Branding */
+
+body:not(.title-tagline-hidden) .custom-logo-link {
+	margin-left: 1em;
+	margin-right: 0;
+}
+
 /* Main Navigation */
 
 .main-navigation ul {

--- a/style.css
+++ b/style.css
@@ -2284,25 +2284,25 @@ object {
 	border: 0;
 }
 
-#main .wp-playlist {
-	padding: 10px 10px 5px;
+.site-content .wp-playlist {
+	padding: 0.625em 0.625em 0.3125em;
 }
 
-#main .wp-playlist-light {
+.site-content .wp-playlist-light {
 	border-color: #eee;
 	color: #222;
 }
 
-#main .wp-playlist-current-item .wp-playlist-item-title {
+.site-content .wp-playlist-current-item .wp-playlist-item-title {
 	font-weight: 700;
 }
 
-#main .wp-playlist-current-item .wp-playlist-item-album {
+.site-content .wp-playlist-current-item .wp-playlist-item-album {
 	color: #333;
 	font-style: normal;
 }
 
-#main .wp-playlist-current-item .wp-playlist-item-artist {
+.site-content .wp-playlist-current-item .wp-playlist-item-artist {
 	color: #767676;
 	font-size: 10px;
 	font-size: 0.625rem;
@@ -2311,36 +2311,36 @@ object {
 	text-transform: uppercase;
 }
 
-#main .wp-playlist-item {
-	padding: 0 5px;
+.site-content .wp-playlist-item {
+	padding: 0 0.3125em;
 	border-bottom: 1px dotted #eee;
 	-webkit-transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
 	transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
 	cursor: pointer;
 }
 
-#main .wp-playlist-item:last-of-type {
+.site-content .wp-playlist-item:last-of-type {
 	border-bottom: none;
 }
 
-#main .wp-playlist-item:hover,
-#main .wp-playlist-item:focus {
+.site-content .wp-playlist-item:hover,
+.site-content .wp-playlist-item:focus {
 	border-bottom-color: rgba(0, 0, 0, 0);
 	background-color: #767676;
 	color: #fff;
 }
 
-#main .wp-playlist-item a {
-	padding: 5px 0;
+.site-content .wp-playlist-item a {
+	padding: 0.3125em 0;
 	border-bottom: none;
 }
 
-#main .wp-playlist-item a:hover {
+.site-content .wp-playlist-item a:hover {
 	border-bottom: none;
 	background: transparent;
 }
 
-#main .wp-playlist-item-length {
+.site-content .wp-playlist-item-length {
 	top: 5px;
 }
 

--- a/style.css
+++ b/style.css
@@ -2158,7 +2158,6 @@ h2.widget-title {
 
 img {
 	height: auto; /* Make sure images are scaled correctly. */
-	width: inherit;  /* Make images fill their parent's space. Solves IE8. */
 	max-width: 100%; /* Adhere to container width. */
 }
 

--- a/style.css
+++ b/style.css
@@ -2284,13 +2284,10 @@ object {
 	border: 0;
 }
 
+/* Playlist Style Overrides */
+
 .site-content .wp-playlist {
 	padding: 0.625em 0.625em 0.3125em;
-}
-
-.site-content .wp-playlist-light {
-	border-color: #eee;
-	color: #222;
 }
 
 .site-content .wp-playlist-current-item .wp-playlist-item-title {
@@ -2298,12 +2295,10 @@ object {
 }
 
 .site-content .wp-playlist-current-item .wp-playlist-item-album {
-	color: #333;
 	font-style: normal;
 }
 
 .site-content .wp-playlist-current-item .wp-playlist-item-artist {
-	color: #767676;
 	font-size: 10px;
 	font-size: 0.625rem;
 	font-weight: 800;
@@ -2313,21 +2308,11 @@ object {
 
 .site-content .wp-playlist-item {
 	padding: 0 0.3125em;
-	border-bottom: 1px dotted #eee;
-	-webkit-transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
-	transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
 	cursor: pointer;
 }
 
 .site-content .wp-playlist-item:last-of-type {
 	border-bottom: none;
-}
-
-.site-content .wp-playlist-item:hover,
-.site-content .wp-playlist-item:focus {
-	border-bottom-color: rgba(0, 0, 0, 0);
-	background-color: #767676;
-	color: #fff;
 }
 
 .site-content .wp-playlist-item a {
@@ -2342,6 +2327,34 @@ object {
 
 .site-content .wp-playlist-item-length {
 	top: 5px;
+}
+
+/* Playlist Color Overrides */
+
+.site-content .wp-playlist-light {
+	border-color: #eee;
+	color: #222;
+}
+
+.site-content .wp-playlist-light .wp-playlist-current-item .wp-playlist-item-album {
+	color: #333;
+}
+
+.site-content .wp-playlist-light .wp-playlist-current-item .wp-playlist-item-artist {
+	color: #767676;
+}
+
+.site-content .wp-playlist-light .wp-playlist-item {
+	border-bottom: 1px dotted #eee;
+	-webkit-transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
+	transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
+}
+
+.site-content .wp-playlist-light .wp-playlist-item:hover,
+.site-content .wp-playlist-light .wp-playlist-item:focus {
+	border-bottom-color: rgba(0, 0, 0, 0);
+	background-color: #767676;
+	color: #fff;
 }
 
 /* SVG Icons base styles */

--- a/style.css
+++ b/style.css
@@ -2284,6 +2284,66 @@ object {
 	border: 0;
 }
 
+#main .wp-playlist {
+	padding: 10px 10px 5px;
+}
+
+#main .wp-playlist-light {
+	border-color: #eee;
+	color: #222;
+}
+
+#main .wp-playlist-current-item .wp-playlist-item-title {
+	font-weight: 700;
+}
+
+#main .wp-playlist-current-item .wp-playlist-item-album {
+	color: #333;
+	font-style: normal;
+}
+
+#main .wp-playlist-current-item .wp-playlist-item-artist {
+	color: #767676;
+	font-size: 10px;
+	font-size: 0.625rem;
+	font-weight: 800;
+	letter-spacing: 0.1818em;
+	text-transform: uppercase;
+}
+
+#main .wp-playlist-item {
+	padding: 0 5px;
+	border-bottom: 1px dotted #eee;
+	-webkit-transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
+	transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
+	cursor: pointer;
+}
+
+#main .wp-playlist-item:last-of-type {
+	border-bottom: none;
+}
+
+#main .wp-playlist-item:hover,
+#main .wp-playlist-item:focus {
+	border-bottom-color: rgba(0, 0, 0, 0);
+	background-color: #767676;
+	color: #fff;
+}
+
+#main .wp-playlist-item a {
+	padding: 5px 0;
+	border-bottom: none;
+}
+
+#main .wp-playlist-item a:hover {
+	border-bottom: none;
+	background: transparent;
+}
+
+#main .wp-playlist-item-length {
+	top: 5px;
+}
+
 /* SVG Icons base styles */
 
 .icon {

--- a/style.css
+++ b/style.css
@@ -1247,6 +1247,7 @@ body {
 }
 
 .site-title {
+	clear: none;
 	font-size: 24px;
 	font-size: 1.5rem;
 	font-weight: 800;
@@ -1283,13 +1284,32 @@ body {
 }
 
 .custom-logo-link img {
+	display: inline-block;
+	margin-bottom: 1em;
 	max-height: 200px;
+	max-width: 100%;
 	width: auto;
 }
 
 .custom-logo-link a:hover,
 .custom-logo-link a:focus {
 	opacity: 0.9;
+}
+
+body:not(.title-tagline-hidden) .custom-logo-link {
+	display: inline-block;
+	margin-right: 1em;
+	vertical-align: middle;
+}
+
+body:not(.title-tagline-hidden) .custom-logo-link img {
+	margin-bottom: 0;
+	max-height: 80px;
+}
+
+body:not(.title-tagline-hidden) .site-branding-text {
+	display: inline-block;
+	vertical-align: middle;
 }
 
 .custom-header {
@@ -2684,14 +2704,6 @@ article.panel-placeholder {
 	}
 
 	.custom-logo-link img {
-		max-height: 400px;
-		max-width: 400px;
-	}
-
-	.twentyseventeen-front-page:not(.no-header-image) .custom-logo-link img,
-	.home.blog:not(.no-header-image) .custom-logo-link img {
-		max-height: 500px;
-		max-width: 500px;
 	}
 
 	/* Navigation */

--- a/style.css
+++ b/style.css
@@ -1285,7 +1285,6 @@ body {
 
 .custom-logo-link img {
 	display: inline-block;
-	margin-bottom: 1em;
 	max-height: 200px;
 	max-width: 100%;
 	width: auto;
@@ -1300,6 +1299,10 @@ body:not(.title-tagline-hidden) .custom-logo-link {
 	display: inline-block;
 	margin-right: 1em;
 	vertical-align: middle;
+}
+
+body:not(.home) .custom-logo-link img {
+	max-height: 100px;
 }
 
 body:not(.title-tagline-hidden) .custom-logo-link img {
@@ -2773,9 +2776,6 @@ article.panel-placeholder {
 	.site-description {
 		font-size: 16px;
 		font-size: 1rem;
-	}
-
-	.custom-logo-link img {
 	}
 
 	/* Navigation */

--- a/style.css
+++ b/style.css
@@ -1285,7 +1285,6 @@ body {
 
 .custom-logo-link img {
 	display: inline-block;
-	margin-bottom: 1em;
 	max-height: 200px;
 	max-width: 100%;
 	width: auto;
@@ -1300,6 +1299,10 @@ body:not(.title-tagline-hidden) .custom-logo-link {
 	display: inline-block;
 	margin-right: 1em;
 	vertical-align: middle;
+}
+
+body:not(.home) .custom-logo-link img {
+	max-height: 100px;
 }
 
 body:not(.title-tagline-hidden) .custom-logo-link img {
@@ -2701,9 +2704,6 @@ article.panel-placeholder {
 	.site-description {
 		font-size: 16px;
 		font-size: 1rem;
-	}
-
-	.custom-logo-link img {
 	}
 
 	/* Navigation */

--- a/style.css
+++ b/style.css
@@ -1283,9 +1283,15 @@ body {
 	opacity: 0.8;
 }
 
-.custom-logo-link img {
+.custom-logo-link {
 	display: inline-block;
-	max-height: 200px;
+	padding-right: 1em;
+	vertical-align: middle;
+	width: auto;
+}
+
+.custom-logo-link img {
+	max-height: 80px;
 	max-width: 100%;
 	width: auto;
 }
@@ -1293,21 +1299,6 @@ body {
 .custom-logo-link a:hover,
 .custom-logo-link a:focus {
 	opacity: 0.9;
-}
-
-body:not(.title-tagline-hidden) .custom-logo-link {
-	display: inline-block;
-	margin-right: 1em;
-	vertical-align: middle;
-}
-
-body:not(.home) .custom-logo-link img {
-	max-height: 100px;
-}
-
-body:not(.title-tagline-hidden) .custom-logo-link img {
-	margin-bottom: 0;
-	max-height: 80px;
 }
 
 body:not(.title-tagline-hidden) .site-branding-text {
@@ -2766,6 +2757,26 @@ article.panel-placeholder {
 
 	.no-header-image .custom-header-image {
 		min-height: 20vh;
+	}
+
+	.custom-logo-link {
+		padding-right: 2em;
+	}
+
+	.custom-logo-link img {
+		max-width: 350px;
+	}
+
+	.home:not(.no-header-image) .custom-logo-link img {
+		max-width: 500px;
+	}
+
+	.title-tagline-hidden.home:not(.no-header-image) .custom-logo-link img {
+		max-height: 200px;
+	}
+
+	.title-tagline-hidden.home:not(.no-header-image) .custom-logo-link img {
+		max-width: 700px;
 	}
 
 	.site-title {

--- a/style.css
+++ b/style.css
@@ -1285,10 +1285,13 @@ body {
 
 .custom-logo-link img {
 	display: inline-block;
-	margin-bottom: 1em;
+	max-height: 80px;
+	width: auto;
+}
+
+body.home.title-tagline-hidden:not(.no-header-image) .custom-logo-link img {
 	max-height: 200px;
 	max-width: 100%;
-	width: auto;
 }
 
 .custom-logo-link a:hover,
@@ -1300,12 +1303,6 @@ body:not(.title-tagline-hidden) .custom-logo-link {
 	display: inline-block;
 	margin-right: 1em;
 	vertical-align: middle;
-}
-
-body:not(.title-tagline-hidden) .custom-logo-link img,
-body:not(.home) .custom-logo-link img {
-	margin-bottom: 0;
-	max-height: 80px;
 }
 
 body:not(.title-tagline-hidden) .site-branding-text {

--- a/style.css
+++ b/style.css
@@ -1247,6 +1247,7 @@ body {
 }
 
 .site-title {
+	clear: none;
 	font-size: 24px;
 	font-size: 1.5rem;
 	font-weight: 800;
@@ -1283,13 +1284,32 @@ body {
 }
 
 .custom-logo-link img {
+	display: inline-block;
+	margin-bottom: 1em;
 	max-height: 200px;
+	max-width: 100%;
 	width: auto;
 }
 
 .custom-logo-link a:hover,
 .custom-logo-link a:focus {
 	opacity: 0.9;
+}
+
+body:not(.title-tagline-hidden) .custom-logo-link {
+	display: inline-block;
+	margin-right: 1em;
+	vertical-align: middle;
+}
+
+body:not(.title-tagline-hidden) .custom-logo-link img {
+	margin-bottom: 0;
+	max-height: 80px;
+}
+
+body:not(.title-tagline-hidden) .site-branding-text {
+	display: inline-block;
+	vertical-align: middle;
 }
 
 .custom-header {
@@ -2756,14 +2776,6 @@ article.panel-placeholder {
 	}
 
 	.custom-logo-link img {
-		max-height: 400px;
-		max-width: 400px;
-	}
-
-	.twentyseventeen-front-page:not(.no-header-image) .custom-logo-link img,
-	.home.blog:not(.no-header-image) .custom-logo-link img {
-		max-height: 500px;
-		max-width: 500px;
 	}
 
 	/* Navigation */

--- a/style.css
+++ b/style.css
@@ -2768,20 +2768,13 @@ article.panel-placeholder {
 		padding-right: 2em;
 	}
 
-	.custom-logo-link img {
+	.custom-logo-link img,
+	body.home.title-tagline-hidden:not(.no-header-image) .custom-logo-link img {
 		max-width: 350px;
-	}
-
-	.home:not(.no-header-image) .custom-logo-link img {
-		max-width: 500px;
 	}
 
 	.title-tagline-hidden.home:not(.no-header-image) .custom-logo-link img {
 		max-height: 200px;
-	}
-
-	.title-tagline-hidden.home:not(.no-header-image) .custom-logo-link img {
-		max-width: 700px;
 	}
 
 	.site-title {

--- a/style.css
+++ b/style.css
@@ -1241,6 +1241,7 @@ body {
 }
 
 .site-title {
+	clear: none;
 	font-size: 24px;
 	font-size: 1.5rem;
 	font-weight: 800;
@@ -1277,13 +1278,32 @@ body {
 }
 
 .custom-logo-link img {
+	display: inline-block;
+	margin-bottom: 1em;
 	max-height: 200px;
+	max-width: 100%;
 	width: auto;
 }
 
 .custom-logo-link a:hover,
 .custom-logo-link a:focus {
 	opacity: 0.9;
+}
+
+body:not(.title-tagline-hidden) .custom-logo-link {
+	display: inline-block;
+	margin-right: 1em;
+	vertical-align: middle;
+}
+
+body:not(.title-tagline-hidden) .custom-logo-link img {
+	margin-bottom: 0;
+	max-height: 80px;
+}
+
+body:not(.title-tagline-hidden) .site-branding-text {
+	display: inline-block;
+	vertical-align: middle;
 }
 
 .custom-header {
@@ -2678,14 +2698,6 @@ article.panel-placeholder {
 	}
 
 	.custom-logo-link img {
-		max-height: 400px;
-		max-width: 400px;
-	}
-
-	.twentyseventeen-front-page:not(.no-header-image) .custom-logo-link img,
-	.home.blog:not(.no-header-image) .custom-logo-link img {
-		max-height: 500px;
-		max-width: 500px;
 	}
 
 	/* Navigation */


### PR DESCRIPTION
Related to #345.

Updating logo styles to be similar to mockup in #119. Site title and description will float next to the logo when it's present, and the hope is that the logo will be a bit larger when the site title is hidden.

Currently this behaviour is there, but it uses 'refresh' to update 'header_textcolor' in the Customizer, which isn't great. I haven't actually reduced the image size yet, either.

Would appreciate any thoughts on improving how the Customizer handles this, if possible!
