### PR TITLE
Use `get_parent_theme_file_path` to include color patterns.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -231,7 +231,7 @@ function twentyseventeen_colors_css_wrap() {
 		return;
 	}
 
-	require_once( 'inc/color-patterns.php' );
+	require_once( get_parent_theme_file_path( '/inc/color-patterns.php' ) );
 	$hue = absint( get_theme_mod( 'colorscheme_hue', 250 ) );
 ?>
 	<style type="text/css" id="custom-theme-colors" <?php if ( is_customize_preview() ) { echo 'data-hue="' . $hue . '"'; } ?>>


### PR DESCRIPTION
- This way, child themes can easily override the file.

Fixes #384.
