### PR TITLE
Add support for Devanagari

### DIFF
--- a/style.css
+++ b/style.css
@@ -550,6 +550,48 @@ q:after {
 	outline: none;
 }
 
+/* Typography for Devanagari Font */
+
+html[lang="bn-BD"] body,
+html[lang="bn-BD"] button,
+html[lang="bn-BD"] input,
+html[lang="bn-BD"] select,
+html[lang="bn-BD"] textarea,
+html[lang="hi-IN"] body,
+html[lang="hi-IN"] button,
+html[lang="hi-IN"] input,
+html[lang="hi-IN"] select,
+html[lang="hi-IN"] textarea,
+html[lang="mr-IN"] body,
+html[lang="mr-IN"] button,
+html[lang="mr-IN"] input,
+html[lang="mr-IN"] select,
+html[lang="mr-IN"] textarea {
+	font-family: Arial, sans-serif;
+}
+
+html[lang="bn-BD"] h1,
+html[lang="bn-BD"] h2,
+html[lang="bn-BD"] h3,
+html[lang="bn-BD"] h4,
+html[lang="bn-BD"] h5,
+html[lang="bn-BD"] h6,
+html[lang="hi-IN"] h1,
+html[lang="hi-IN"] h2,
+html[lang="hi-IN"] h3,
+html[lang="hi-IN"] h4,
+html[lang="hi-IN"] h5,
+html[lang="hi-IN"] h6,
+html[lang="mr-IN"] h1,
+html[lang="mr-IN"] h2,
+html[lang="mr-IN"] h3,
+html[lang="mr-IN"] h4,
+html[lang="mr-IN"] h5,
+html[lang="mr-IN"] h6 {
+	font-weight: bold;
+	letter-spacing: normal;
+}
+
 /* Typography for Hebrew Font */
 
 html[lang="he-IL"] body,


### PR DESCRIPTION
Adds support for `bn-BD`, `hi-IN`, and `mr-IN`. Please let me know if I missed any, or if there’s a better font alternative than Arial available on either Mac or Windows. 

**Before**:

<img width="804" alt="screen shot 2016-10-16 at 5 40 52 pm" src="https://cloud.githubusercontent.com/assets/2846578/19421161/36ffe9f0-93c8-11e6-936c-81f75b16aec7.png">

**After**:

<img width="814" alt="screen shot 2016-10-16 at 5 40 00 pm" src="https://cloud.githubusercontent.com/assets/2846578/19421162/3b2ae534-93c8-11e6-93e9-053f34e1c606.png">
