### PR TITLE
SVG Fallbacks

### DIFF
--- a/assets/css/ie8.css
+++ b/assets/css/ie8.css
@@ -42,6 +42,7 @@ h6 {
 }
 
 /* Main Navigation */
+
 .menu-toggle {
 	width: 150px;
 }
@@ -49,6 +50,14 @@ h6 {
 .main-navigation ul#top-menu {
 	margin-bottom: -1px;
 	padding: 0;
+}
+
+.dropdown-toggle .svg-fallback.icon-expand {
+	-ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=-1, M12=1.2246467991473532e-16, M21=-1.2246467991473532e-16, M22=-1, SizingMethod='auto expand')";
+}
+
+.dropdown-toggle.toggled-on .svg-fallback.icon-expand {
+	-ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=1, M12=0, M21=0, M22=1, SizingMethod='auto expand')";
 }
 
 /* Front Page */

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -129,14 +129,13 @@
 	}
 
 	/**
-	 * Test if SVGs are supported.
-	 */
-	function supportsSvg() {
+     * Test if inline SVGs are supported.
+     * @link https://github.com/Modernizr/Modernizr/
+     */
+	function supportsInlineSVG() {
 		var div = document.createElement( 'div' );
 		div.innerHTML = '<svg/>';
-		if ( 'http://www.w3.org/2000/svg' !== ( div.firstChild && div.firstChild.namespaceURI ) ) {
-			$body.addClass( 'no-svg' );
-		}
+		return ( typeof SVGRect != 'undefined' && div.firstChild && div.firstChild.namespaceURI ) == 'http://www.w3.org/2000/svg';
 	}
 
 	// Fires on document ready
@@ -160,7 +159,10 @@
 		setNavProps();
 		adjustScrollClass();
 		adjustHeaderHeight();
-		supportsSvg();
+		supportsInlineSVG();
+        if ( supportsInlineSVG() === true ) {
+            document.documentElement.className = document.documentElement.className.replace( /(\s*)no-svg(\s*)/,'$1svg$2' );
+        }
 	} );
 
 	// On scroll, we want to stick/unstick the navigation

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -128,6 +128,17 @@
 		});
 	}
 
+	/**
+	 * Test if SVGs are supported.
+	 */
+	function supportsSvg() {
+		var div = document.createElement('div');
+		div.innerHTML = '<svg/>';
+		if ( 'http://www.w3.org/2000/svg' !== ( div.firstChild && div.firstChild.namespaceURI ) ) {
+			$body.addClass( 'no-svg' );
+		}
+	}
+
 	// Fires on document ready
 	$( document ).ready( function() {
 
@@ -149,6 +160,7 @@
 		setNavProps();
 		adjustScrollClass();
 		adjustHeaderHeight();
+		supportsSvg();
 	} );
 
 	// On scroll, we want to stick/unstick the navigation

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -160,9 +160,9 @@
 		adjustScrollClass();
 		adjustHeaderHeight();
 		supportsInlineSVG();
-        if ( supportsInlineSVG() === true ) {
-            document.documentElement.className = document.documentElement.className.replace( /(\s*)no-svg(\s*)/,'$1svg$2' );
-        }
+		if ( supportsInlineSVG() === true ) {
+			document.documentElement.className = document.documentElement.className.replace( /(\s*)no-svg(\s*)/,'$1svg$2' );
+		}
 	} );
 
 	// On scroll, we want to stick/unstick the navigation

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -132,7 +132,7 @@
 	 * Test if SVGs are supported.
 	 */
 	function supportsSvg() {
-		var div = document.createElement('div');
+		var div = document.createElement( 'div' );
 		div.innerHTML = '<svg/>';
 		if ( 'http://www.w3.org/2000/svg' !== ( div.firstChild && div.firstChild.namespaceURI ) ) {
 			$body.addClass( 'no-svg' );

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -135,7 +135,7 @@
 	function supportsInlineSVG() {
 		var div = document.createElement( 'div' );
 		div.innerHTML = '<svg/>';
-		return ( typeof SVGRect != 'undefined' && div.firstChild && div.firstChild.namespaceURI ) == 'http://www.w3.org/2000/svg';
+		return 'http://www.w3.org/2000/svg' === ( 'undefined' !== typeof SVGRect && div.firstChild && div.firstChild.namespaceURI );
 	}
 
 	// Fires on document ready
@@ -160,8 +160,8 @@
 		adjustScrollClass();
 		adjustHeaderHeight();
 		supportsInlineSVG();
-		if ( supportsInlineSVG() === true ) {
-			document.documentElement.className = document.documentElement.className.replace( /(\s*)no-svg(\s*)/,'$1svg$2' );
+		if ( true === supportsInlineSVG() ) {
+			document.documentElement.className = document.documentElement.className.replace( /(\s*)no-svg(\s*)/, '$1svg$2' );
 		}
 	} );
 

--- a/functions.php
+++ b/functions.php
@@ -270,7 +270,7 @@ function twentyseventeen_scripts() {
 	wp_localize_script( 'twentyseventeen-navigation', 'twentyseventeenScreenReaderText', array(
 		'expand'   => __( 'Expand child menu', 'twentyseventeen' ),
 		'collapse' => __( 'Collapse child menu', 'twentyseventeen' ),
-		'icon'     => twentyseventeen_get_svg( array( 'icon' => 'expand' ) ),
+		'icon'     => twentyseventeen_get_svg( array( 'icon' => 'expand', 'fallback' => true ) ),
 	) );
 
 	wp_enqueue_script( 'twentyseventeen-global', get_theme_file_uri( '/assets/js/global.js' ), array( 'jquery' ), '20151215', true );

--- a/header.php
+++ b/header.php
@@ -13,7 +13,7 @@
  */
 
 ?><!DOCTYPE html>
-<html <?php language_attributes(); ?> class="no-js">
+<html <?php language_attributes(); ?> class="no-js no-svg">
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/inc/icon-functions.php
+++ b/inc/icon-functions.php
@@ -33,7 +33,7 @@ add_action( 'wp_footer', 'twentyseventeen_include_svg_icons', 9999 );
  *     @type string $title Optional SVG title.
  *     @type string $desc  Optional SVG description.
  * }
- * @return string SVG markup.
+ * @return string SVG markup. 
  */
 function twentyseventeen_get_svg( $args = array() ) {
 
@@ -95,7 +95,7 @@ function twentyseventeen_get_svg( $args = array() ) {
 
 	// Add some markup to use as a fallback for browsers that do not support SVGs.
 	if ( $args['fallback'] ) {
-		$svg .= '<span class="svg-fallback icon-'. esc_attr( $args['icon'] ) . '"></span>';
+		$svg .= '<span class="svg-fallback icon-' . esc_attr( $args['icon'] ) . '"></span>';
 	}
 
 	$svg .= '</svg>';

--- a/inc/icon-functions.php
+++ b/inc/icon-functions.php
@@ -92,6 +92,9 @@ function twentyseventeen_get_svg( $args = array() ) {
 		$svg .= '<use xlink:href="#icon-' . esc_html( $args['icon'] ) . '"></use>';
 	}
 
+	// Add some markup to use as a fallback for browsers that do not support SVGs.
+	$svg .= '<span class="svg-fallback icon-'. esc_attr( $args['icon'] ) . '"></span>';
+
 	$svg .= '</svg>';
 
 	return $svg;

--- a/inc/icon-functions.php
+++ b/inc/icon-functions.php
@@ -33,7 +33,7 @@ add_action( 'wp_footer', 'twentyseventeen_include_svg_icons', 9999 );
  *     @type string $title Optional SVG title.
  *     @type string $desc  Optional SVG description.
  * }
- * @return string SVG markup. 
+ * @return string SVG markup.
  */
 function twentyseventeen_get_svg( $args = array() ) {
 

--- a/inc/icon-functions.php
+++ b/inc/icon-functions.php
@@ -53,6 +53,7 @@ function twentyseventeen_get_svg( $args = array() ) {
 		'title'       => '',
 		'desc'        => '',
 		'aria_hidden' => true, // Hide from screen readers.
+		'fallback'    => false,
 	);
 
 	// Parse args.
@@ -93,7 +94,9 @@ function twentyseventeen_get_svg( $args = array() ) {
 	}
 
 	// Add some markup to use as a fallback for browsers that do not support SVGs.
-	$svg .= '<span class="svg-fallback icon-'. esc_attr( $args['icon'] ) . '"></span>';
+	if ( $args['fallback'] ) {
+		$svg .= '<span class="svg-fallback icon-'. esc_attr( $args['icon'] ) . '"></span>';
+	}
 
 	$svg .= '</svg>';
 

--- a/style.css
+++ b/style.css
@@ -2488,6 +2488,68 @@ article.panel-placeholder {
 }
 
 /*--------------------------------------------------------------
+## SVGs Fallbacks
+--------------------------------------------------------------*/
+
+.svg-fallback {
+	display: none;
+}
+
+.no-svg .svg-fallback {
+	display: inline-block;
+}
+
+.no-svg .dropdown-toggle .svg-fallback.icon-expand {
+	font-size: 16px;
+	font-size: 1em;
+	font-weight: 400;
+	line-height: 2.5em;
+	position: absolute;
+	top: 8px;
+	-webkit-transform: rotate(180deg); /* Chrome, Safari, Opera */
+	-ms-transform: rotate(180deg); /* IE 9 */
+	transform: rotate(180deg);
+}
+
+.no-svg .dropdown-toggle.toggled-on .svg-fallback.icon-expand {
+	-webkit-transform: rotate(0); /* Chrome, Safari, Opera */
+	-ms-transform: rotate(0); /* IE 9 */
+	transform: rotate(0);
+}
+
+.no-svg .dropdown-toggle .svg-fallback.icon-expand:before {
+	content: "\005E";
+	display: block;
+	height: 25px;
+	text-align: center;
+	width: 20px;
+}
+
+/* Social Menu fallbacks */
+
+.no-svg .social-navigation a {
+	background: transparent;
+	color: #222;
+	height: auto;
+	width: auto;
+}
+
+/* Show screen reader text in some cases */
+
+.no-svg .next.page-numbers .screen-reader-text,
+.no-svg .prev.page-numbers .screen-reader-text,
+.no-svg .social-navigation li a .screen-reader-text,
+.no-svg .search-submit .screen-reader-text {
+	clip: auto;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 400;
+	height: auto;
+	position: relative !important; /* overrides previous !important styles */
+	width: auto;
+}
+
+/*--------------------------------------------------------------
 ## Media Queries
 --------------------------------------------------------------*/
 

--- a/style.css
+++ b/style.css
@@ -1933,7 +1933,6 @@ body:not(.twentyseventeen-front-page) .entry-header {
 	border-radius: 20px;
 	border: 1px solid #fff;
 	color: #fff;
-	content: "\f408";
 	left: -65px;
 	font-size: 16px;
 	font-size: 1.0rem;


### PR DESCRIPTION
See #347.

Adding fallbacks for the SVGs that have no text labels or other alternatives.

For the pagination previous and next links, social icons, and search button, the `screen-reader-text` has been made visible.

For the mobile menu toggles (also necessary to open/close the menu in IE8), the `^` is inserted as CSS content instead, to preserve space, and is flipped depending on orientation.

Also added another argument to the `twentyseventeen_get_svg()` function, so you can pass 'fallback' HTML to the SVG (needed for situations like the dropdown toggles). 

The styles have all been added to style.css, but they can also be moved to ie8.css.
