### PR TITLE
Add basic playlist styling overrides

### DIFF
--- a/style.css
+++ b/style.css
@@ -2284,25 +2284,25 @@ object {
 	border: 0;
 }
 
-#main .wp-playlist {
-	padding: 10px 10px 5px;
+.site-content .wp-playlist {
+	padding: 0.625em 0.625em 0.3125em;
 }
 
-#main .wp-playlist-light {
+.site-content .wp-playlist-light {
 	border-color: #eee;
 	color: #222;
 }
 
-#main .wp-playlist-current-item .wp-playlist-item-title {
+.site-content .wp-playlist-current-item .wp-playlist-item-title {
 	font-weight: 700;
 }
 
-#main .wp-playlist-current-item .wp-playlist-item-album {
+.site-content .wp-playlist-current-item .wp-playlist-item-album {
 	color: #333;
 	font-style: normal;
 }
 
-#main .wp-playlist-current-item .wp-playlist-item-artist {
+.site-content .wp-playlist-current-item .wp-playlist-item-artist {
 	color: #767676;
 	font-size: 10px;
 	font-size: 0.625rem;
@@ -2311,36 +2311,36 @@ object {
 	text-transform: uppercase;
 }
 
-#main .wp-playlist-item {
-	padding: 0 5px;
+.site-content .wp-playlist-item {
+	padding: 0 0.3125em;
 	border-bottom: 1px dotted #eee;
 	-webkit-transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
 	transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
 	cursor: pointer;
 }
 
-#main .wp-playlist-item:last-of-type {
+.site-content .wp-playlist-item:last-of-type {
 	border-bottom: none;
 }
 
-#main .wp-playlist-item:hover,
-#main .wp-playlist-item:focus {
+.site-content .wp-playlist-item:hover,
+.site-content .wp-playlist-item:focus {
 	border-bottom-color: rgba(0, 0, 0, 0);
 	background-color: #767676;
 	color: #fff;
 }
 
-#main .wp-playlist-item a {
-	padding: 5px 0;
+.site-content .wp-playlist-item a {
+	padding: 0.3125em 0;
 	border-bottom: none;
 }
 
-#main .wp-playlist-item a:hover {
+.site-content .wp-playlist-item a:hover {
 	border-bottom: none;
 	background: transparent;
 }
 
-#main .wp-playlist-item-length {
+.site-content .wp-playlist-item-length {
 	top: 5px;
 }
 

--- a/style.css
+++ b/style.css
@@ -2284,13 +2284,10 @@ object {
 	border: 0;
 }
 
+/* Playlist Style Overrides */
+
 .site-content .wp-playlist {
 	padding: 0.625em 0.625em 0.3125em;
-}
-
-.site-content .wp-playlist-light {
-	border-color: #eee;
-	color: #222;
 }
 
 .site-content .wp-playlist-current-item .wp-playlist-item-title {
@@ -2298,12 +2295,10 @@ object {
 }
 
 .site-content .wp-playlist-current-item .wp-playlist-item-album {
-	color: #333;
 	font-style: normal;
 }
 
 .site-content .wp-playlist-current-item .wp-playlist-item-artist {
-	color: #767676;
 	font-size: 10px;
 	font-size: 0.625rem;
 	font-weight: 800;
@@ -2313,21 +2308,11 @@ object {
 
 .site-content .wp-playlist-item {
 	padding: 0 0.3125em;
-	border-bottom: 1px dotted #eee;
-	-webkit-transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
-	transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
 	cursor: pointer;
 }
 
 .site-content .wp-playlist-item:last-of-type {
 	border-bottom: none;
-}
-
-.site-content .wp-playlist-item:hover,
-.site-content .wp-playlist-item:focus {
-	border-bottom-color: rgba(0, 0, 0, 0);
-	background-color: #767676;
-	color: #fff;
 }
 
 .site-content .wp-playlist-item a {
@@ -2342,6 +2327,34 @@ object {
 
 .site-content .wp-playlist-item-length {
 	top: 5px;
+}
+
+/* Playlist Color Overrides */
+
+.site-content .wp-playlist-light {
+	border-color: #eee;
+	color: #222;
+}
+
+.site-content .wp-playlist-light .wp-playlist-current-item .wp-playlist-item-album {
+	color: #333;
+}
+
+.site-content .wp-playlist-light .wp-playlist-current-item .wp-playlist-item-artist {
+	color: #767676;
+}
+
+.site-content .wp-playlist-light .wp-playlist-item {
+	border-bottom: 1px dotted #eee;
+	-webkit-transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
+	transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
+}
+
+.site-content .wp-playlist-light .wp-playlist-item:hover,
+.site-content .wp-playlist-light .wp-playlist-item:focus {
+	border-bottom-color: rgba(0, 0, 0, 0);
+	background-color: #767676;
+	color: #fff;
 }
 
 /* SVG Icons base styles */

--- a/style.css
+++ b/style.css
@@ -2284,6 +2284,66 @@ object {
 	border: 0;
 }
 
+#main .wp-playlist {
+	padding: 10px 10px 5px;
+}
+
+#main .wp-playlist-light {
+	border-color: #eee;
+	color: #222;
+}
+
+#main .wp-playlist-current-item .wp-playlist-item-title {
+	font-weight: 700;
+}
+
+#main .wp-playlist-current-item .wp-playlist-item-album {
+	color: #333;
+	font-style: normal;
+}
+
+#main .wp-playlist-current-item .wp-playlist-item-artist {
+	color: #767676;
+	font-size: 10px;
+	font-size: 0.625rem;
+	font-weight: 800;
+	letter-spacing: 0.1818em;
+	text-transform: uppercase;
+}
+
+#main .wp-playlist-item {
+	padding: 0 5px;
+	border-bottom: 1px dotted #eee;
+	-webkit-transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
+	transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.3s ease-in-out;
+	cursor: pointer;
+}
+
+#main .wp-playlist-item:last-of-type {
+	border-bottom: none;
+}
+
+#main .wp-playlist-item:hover,
+#main .wp-playlist-item:focus {
+	border-bottom-color: rgba(0, 0, 0, 0);
+	background-color: #767676;
+	color: #fff;
+}
+
+#main .wp-playlist-item a {
+	padding: 5px 0;
+	border-bottom: none;
+}
+
+#main .wp-playlist-item a:hover {
+	border-bottom: none;
+	background: transparent;
+}
+
+#main .wp-playlist-item-length {
+	top: 5px;
+}
+
 /* SVG Icons base styles */
 
 .icon {


### PR DESCRIPTION
Fixes #137. Needs a LOT of testing and review.

**Before**:

![twentyseventeen-audio-playlist](https://cloud.githubusercontent.com/assets/7875961/19100106/b8e85404-8a70-11e6-8dc5-8974ed0c5217.png)

<img width="616" alt="screen shot 2016-10-05 at 6 26 39 pm" src="https://cloud.githubusercontent.com/assets/2846578/19134009/53d104da-8b29-11e6-8197-575204806836.png">

**After**:

<img width="767" alt="screen shot 2016-10-16 at 9 20 26 pm" src="https://cloud.githubusercontent.com/assets/2846578/19422701/875529b0-93e6-11e6-9f32-72dc87f064d6.png">

<img width="694" alt="screen shot 2016-10-16 at 9 20 12 pm" src="https://cloud.githubusercontent.com/assets/2846578/19422700/87540bfc-93e6-11e6-86d3-eca6f18d752c.png">
