### PR TITLE
Remove duplicate scroll event on menu arrow button

### DIFF
--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -26,14 +26,14 @@
 	/**
 	 * Sets properties of navigation
 	 */
-	 function setNavProps() {
-		 navigationHeight      = $navigation.height();
-		 navigationOuterHeight = $navigation.outerHeight();
-		 navPadding            = parseFloat( $navWrap.css( 'padding-top' ) ) * 2;
-		 navMenuItemHeight     = $navMenuItem.outerHeight() * 2;
-		 idealNavHeight        = navPadding + navMenuItemHeight;
-		 navIsNotTooTall       = navigationHeight <= idealNavHeight;
-	 }
+	function setNavProps() {
+		navigationHeight      = $navigation.height();
+		navigationOuterHeight = $navigation.outerHeight();
+		navPadding            = parseFloat( $navWrap.css( 'padding-top' ) ) * 2;
+		navMenuItemHeight     = $navMenuItem.outerHeight() * 2;
+		idealNavHeight        = navPadding + navMenuItemHeight;
+		navIsNotTooTall       = navigationHeight <= idealNavHeight;
+	}
 
 	/**
 	 * Makes navigation 'stick'

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -80,23 +80,6 @@
 	}
 
 	/**
-	 * 'Scroll Down' arrow in menu area
-	 */
-	if ( $( 'body' ).hasClass( 'blog' ) ) {
-		menuTop -= 30; // The div for latest posts has no space above content, add some to account for this
-	}
-	if ( $( 'body' ).hasClass( 'admin-bar' ) ) {
-		menuTop -= 32;
-	}
-	$( '.menu-scroll-down' ).click( function( e ) {
-		e.preventDefault();
-		$( window ).scrollTo( '#primary', {
-			duration: 600,
-			offset: { 'top': menuTop - $navigation.outerHeight() }
-		} );
-	} );
-
-	/**
 	 * Add 'below-entry-meta' class to elements.
 	 */
 	function belowEntryMetaClass( param ) {
@@ -137,11 +120,14 @@
 		if ( $( 'body' ).hasClass( 'admin-bar' ) ) {
 			menuTop = -32;
 		}
+		if ( $( 'body' ).hasClass( 'blog' ) ) {
+			menuTop -= 30; // The div for latest posts has no space above content, add some to account for this
+		}
 		$menuScrollDown.click( function( e ) {
 			e.preventDefault();
 			$( window ).scrollTo( '#primary', {
 				duration: 600,
-				offset: { 'top': menuTop }
+				offset: { 'top': menuTop - navigationOuterHeight }
 			} );
 		} );
 


### PR DESCRIPTION
The click event for the menu scroll element is currently being called twice, with slightly different scroll positions, leading to a interrupted scroll experience (as the window scrolls to the first point, stops, then moves to the next scroll point). [See screen recording.](https://cloudup.com/c2O6tb4_1aZ)

This PR removes the original `click()`  handler in favor of the new handler inside `$( document ).ready`, which already makes use of cached elements.

(I also removed some leading spaces from `setNavProps`, but I can pull those into a 2nd PR if you want)
