### PR TITLE
Switch to a proper callback function for menu `fallback_cb`

### DIFF
--- a/components/navigation/navigation-top.php
+++ b/components/navigation/navigation-top.php
@@ -14,7 +14,7 @@
 	<?php wp_nav_menu( array(
 		'theme_location' => 'top',
 		'menu_id'        => 'top-menu',
-		'fallback_cb'    => wp_page_menu( array( 'link_after' => twentyseventeen_get_svg( array( 'icon' => 'expand' ) ) ) ),
+		'fallback_cb'    => 'twentyseventeen_fallback_menu',
 	) ); ?>
 
 	<?php if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) : ?>

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -96,3 +96,12 @@ function twentyseventeen_is_frontpage() {
 function twentyseventeen_is_page() {
 	return ( is_page() && ! twentyseventeen_is_frontpage() );
 }
+
+/**
+ * Display a default list of pages if no menu is selected.
+ */
+function twentyseventeen_fallback_menu() {
+	wp_page_menu( array(
+		'link_after' => twentyseventeen_get_svg( array( 'icon' => 'expand' ) )
+	) );
+}

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -102,6 +102,6 @@ function twentyseventeen_is_page() {
  */
 function twentyseventeen_fallback_menu() {
 	wp_page_menu( array(
-		'link_after' => twentyseventeen_get_svg( array( 'icon' => 'expand' ) )
+		'link_after' => twentyseventeen_get_svg( array( 'icon' => 'expand' ) ),
 	) );
 }


### PR DESCRIPTION
Currently the `fallback_cb` code is always running, displaying a second menu even if one is already set. This should be a proper callback, so I've created a new function for the menu fallback & swapped it into the callback parameter.
