### PR TITLE
Add the custom header image to the interior pages.

### DIFF
--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -14,6 +14,7 @@
 			$sidebar = $body.find( '#secondary' ),
 			$entryContent = $body.find( '.entry-content' ),
 			$formatQuote = $body.find( '.format-quote blockquote' ),
+			isFrontPage = $body.hasClass( 'twentyseventeen-front-page' ) || $body.hasClass( 'home blog' ),
 			navigationFixedClass = 'site-navigation-fixed',
 			navigationHeight,
 			navigationOuterHeight,
@@ -49,7 +50,7 @@
 			if ( navIsNotTooTall ) {
 
 				// When there's a custom header image, the header offset includes the height of the navigation
-				if ( $customHeaderImage.length ) {
+				if ( isFrontPage && $customHeaderImage.length ) {
 					headerOffset = $customHeader.innerHeight() - navigationOuterHeight;
 				} else {
 					headerOffset = $customHeader.innerHeight();
@@ -75,9 +76,14 @@
 	 */
 	function adjustHeaderHeight() {
 		if ( 'none' === $menuToggle.css( 'display' ) ) {
-			$branding.css( 'margin-bottom', navigationOuterHeight );
+			// The margin should be applied to different elements on front-page or home vs interior pages.
+			if ( isFrontPage ) {
+				$branding.css( 'margin-bottom', navigationOuterHeight );
+			} else {
+				$customHeader.css( 'margin-bottom', navigationOuterHeight );
+			}
 		} else {
-			$branding.css( 'margin-bottom', '0' );
+			$customHeader.css( 'margin-bottom', '0' );
 		}
 	}
 

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -86,6 +86,7 @@
 
 		} else {
 			$customHeader.css( 'margin-bottom', '0' );
+			$branding.css( 'margin-bottom', '0' );
 		}
 	}
 

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -76,12 +76,14 @@
 	 */
 	function adjustHeaderHeight() {
 		if ( 'none' === $menuToggle.css( 'display' ) ) {
+
 			// The margin should be applied to different elements on front-page or home vs interior pages.
 			if ( isFrontPage ) {
 				$branding.css( 'margin-bottom', navigationOuterHeight );
 			} else {
 				$customHeader.css( 'margin-bottom', navigationOuterHeight );
 			}
+
 		} else {
 			$customHeader.css( 'margin-bottom', '0' );
 		}

--- a/components/header/header-image.php
+++ b/components/header/header-image.php
@@ -11,38 +11,29 @@
 ?>
 <div class="custom-header">
 	<?php
+	$header_image = get_header_image();
 
-		// If front page.
-		if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) :
+	// Check if Custom Header image has been added.
+	if ( ! empty( $header_image ) ) : ?>
 
-			// Check if Custom Header image has been added.
-			$header_image = get_header_image();
-			if ( ! empty( $header_image ) ) : ?>
+		<div class="custom-header-image" style="background-image: url(<?php echo esc_url( $header_image ); ?>)"></div>
+		<?php get_template_part( 'components/header/site', 'branding' ); ?>
 
-				<div class="custom-header-image" style="background-image: url(<?php echo esc_url( $header_image ); ?>)"></div>
-				<?php get_template_part( 'components/header/site', 'branding' ); ?>
+	<?php elseif ( twentyseventeen_is_frontpage() && has_post_thumbnail() ) :
+		// If not, fall back to front page's featured image, only on the front page.
+		$post_thumbnail_id = get_post_thumbnail_id( $post->ID );
+		$thumbnail_attributes = wp_get_attachment_image_src( $post_thumbnail_id, 'twentyseventeen-featured-image' );
+		?>
 
-			<?php elseif ( twentyseventeen_is_frontpage() && has_post_thumbnail() ) :
-				// If not, fall back to front page's featured image.
-				$post_thumbnail_id = get_post_thumbnail_id( $post->ID );
-				$thumbnail_attributes = wp_get_attachment_image_src( $post_thumbnail_id, 'twentyseventeen-featured-image' );
-				?>
+		<div class="custom-header-image" style="background-image: url(<?php echo esc_url( $thumbnail_attributes[0] ); ?>)"></div>
+		<?php get_template_part( 'components/header/site', 'branding' ); ?>
 
-				<div class="custom-header-image" style="background-image: url(<?php echo esc_url( $thumbnail_attributes[0] ); ?>)"></div>
-				<?php get_template_part( 'components/header/site', 'branding' ); ?>
+	<?php else : ?>
+		<?php // Otherwise, show a blank header. ?>
+		<div class="custom-header-simple">
+			<?php get_template_part( 'components/header/site', 'branding' ); ?>
+		</div><!-- .custom-header-simple -->
 
-			<?php else : ?>
-				<?php // Otherwise, show a blank header. ?>
-				<div class="custom-header-simple">
-					<?php get_template_part( 'components/header/site', 'branding' ); ?>
-				</div><!-- .custom-header-simple -->
-
-			<?php endif;
-		// If not the front page, show a shorter plain header.
-		else : ?>
-			<div class="custom-header-simple">
-				<?php get_template_part( 'components/header/site', 'branding' ); ?>
-			</div><!-- .custom-header-simple -->
 	<?php endif; ?>
 
 </div><!-- .custom-header -->

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -39,6 +39,11 @@ function twentyseventeen_body_classes( $classes ) {
 		$classes[] = 'no-header-image';
 	}
 
+	// Add a class if there is a featured image or custom header.
+	if ( has_header_image() || ( has_post_thumbnail() && twentyseventeen_is_frontpage() ) ) {
+		$classes[] = 'has-header-image';
+	}
+
 	// Add class if sidebar is used.
 	if ( is_active_sidebar( 'sidebar-1' ) && ! is_page() ) {
 		$classes[] = 'has-sidebar';

--- a/style.css
+++ b/style.css
@@ -1562,6 +1562,26 @@ body:not(.title-tagline-hidden) .site-branding-text {
 	background-position: center center;
 	background-repeat: no-repeat;
 	background-size: cover;
+	height: 165px;
+}
+
+.custom-header-image:before {
+	/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#000000+0,000000+100&0+0,0.3+75 */
+	background: -moz-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* FF3.6-15 */
+	background: -webkit-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* Chrome10-25,Safari5.1-6 */
+	background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#00000000", endColorstr="#4d000000", GradientType=0); /* IE6-9 */
+	bottom: 0;
+	content: "";
+	display: block;
+	height: 100%;
+	left: 0;
+	position: absolute;
+	right: 0;
+}
+
+.twentyseventeen-front-page.has-header-image .custom-header-image,
+.home.blog.has-header-image .custom-header-image {
 	height: 0;
 	padding-top: 66%;
 }
@@ -3144,24 +3164,8 @@ article.panel-placeholder {
 
 	.custom-header-image {
 		height: 165px;
-		padding: 10% 0;
 		position: relative;
 		background-position: bottom;
-	}
-
-	.custom-header-image:before {
-		/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#000000+0,000000+100&0+0,0.3+75 */
-		background: -moz-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* FF3.6-15 */
-		background: -webkit-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* Chrome10-25,Safari5.1-6 */
-		background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
-		filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#00000000", endColorstr="#4d000000", GradientType=0); /* IE6-9 */
-		bottom: 0;
-		content: "";
-		display: block;
-		height: 100%;
-		left: 0;
-		position: absolute;
-		right: 0;
 	}
 
 	.no-header-image .custom-header-image {
@@ -3439,6 +3443,7 @@ article.panel-placeholder {
 		height: 1200px;
 		height: 100vh;
 		max-height: 100%;
+		padding: 10% 0;
 	}
 
 	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image:before,

--- a/style.css
+++ b/style.css
@@ -1475,8 +1475,7 @@ body {
 	transition: margin-bottom 0.2s;
 }
 
-.twentyseventeen-front-page:not(.no-header-image) .site-branding,
-.home.blog:not(.no-header-image) .site-branding {
+body.has-header-image .site-branding {
 	bottom: 0;
 	position: absolute;
 	width: 100%;
@@ -1510,10 +1509,8 @@ body {
 	color: #222;
 }
 
-.twentyseventeen-front-page:not(.no-header-image) .site-title,
-.twentyseventeen-front-page:not(.no-header-image) .site-title a,
-.home.blog:not(.no-header-image) .site-title,
-.home.blog:not(.no-header-image) .site-title a {
+body.has-header-image .site-title,
+body.has-header-image .site-title a {
 	color: #fff;
 }
 
@@ -1524,8 +1521,7 @@ body {
 	margin-bottom: 0;
 }
 
-.twentyseventeen-front-page:not(.no-header-image) .site-description,
-.home.blog:not(.no-header-image) .site-description {
+body.has-header-image .site-description {
 	color: #fff;
 	opacity: 0.8;
 }
@@ -3143,14 +3139,14 @@ article.panel-placeholder {
 	/* Site Branding */
 
 	.site-branding {
-		margin-bottom: 70px;
+		margin-bottom: 0;
 	}
 
 	.custom-header-image {
-		height: 750px;
-		height: 75vh;
+		height: 165px;
 		padding: 10% 0;
 		position: relative;
+		background-position: bottom;
 	}
 
 	.custom-header-image:before {
@@ -3162,7 +3158,7 @@ article.panel-placeholder {
 		bottom: 0;
 		content: "";
 		display: block;
-		height: 33%;
+		height: 100%;
 		left: 0;
 		position: absolute;
 		right: 0;
@@ -3433,11 +3429,21 @@ article.panel-placeholder {
 
 	/* Front Page */
 
+	.twentyseventeen-front-page:not(.no-header-image) .site-branding,
+	.home.blog:not(.no-header-image) .site-branding {
+		margin-bottom: 70px;
+	}
+
 	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
 	.home.blog:not(.no-header-image) .custom-header-image {
 		height: 1200px;
 		height: 100vh;
 		max-height: 100%;
+	}
+
+	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image:before,
+	.home.blog:not(.no-header-image) .custom-header-image:before {
+		height: 33%;
 	}
 
 	.admin-bar.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
@@ -3775,10 +3781,6 @@ article.panel-placeholder {
 }
 
 @media screen and ( min-width: 55em ) {
-
-	.custom-header-image {
-		background-attachment: fixed;
-	}
 
 	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
 	.home.blog:not(.no-header-image) .custom-header-image {


### PR DESCRIPTION
Fixes #413

I've refactored the header-image code to display the custom header on all pages, but kept the functionality of only showing a page's featured image on the front page.

I also added a new class to the body, `has-header-image`. None of the existing interior styles have been removed, as those still apply if no header is set. Instead, I'm using the new class to set the site-title color etc, instead of relying on home or `twentyseventeen-front-page`.

The JS is also tweaked slightly to account for interior menu positioning.

I did not touch the other color schemes, but they'll need to be updated too — I can do this tomorrow.
