### PR TITLE
Remove border from Front Page's panel in Customizer

### DIFF
--- a/style.css
+++ b/style.css
@@ -2459,13 +2459,8 @@ object {
 	z-index: 3;
 }
 
-.twentyseventeen-customizer.twentyseventeen-front-page .twentyseventeen-panel:nth-of-type(1) .twentyseventeen-panel-title {
-	background: #a64b55;
-}
-
 .twentyseventeen-customizer.twentyseventeen-front-page .twentyseventeen-panel:nth-of-type(1)::after {
-	border-color: #a64b55;
-	color: #a64b55;
+	border: none;
 }
 
 .twentyseventeen-customizer.twentyseventeen-front-page .twentyseventeen-panel:nth-of-type(2) .twentyseventeen-panel-title {


### PR DESCRIPTION
Remove dotted border from front page content panel in the Customizer. Unlike the other panels, it's not edited in the Customizer and doesn't make the same sense to highlight there.

Fixes #223.
