### PR TITLE
Making selector more specific to hide 'scroll-down' arrow on small sc…

### DIFF
--- a/style.css
+++ b/style.css
@@ -1163,7 +1163,7 @@ a:hover .nav-title,
 
 /* Scroll down arrow */
 
-.menu-scroll-down {
+.navigation-top .menu-scroll-down {
 	display: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -1387,7 +1387,7 @@ a:hover .nav-title,
 
 /* Scroll down arrow */
 
-.menu-scroll-down {
+.navigation-top .menu-scroll-down {
 	display: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -1253,7 +1253,7 @@ a:hover .nav-title,
 .js .main-navigation ul,
 .main-navigation .menu-item-has-children > a > .icon,
 .main-navigation .page_item_has_children > a > .icon,
-.main-navigation a > .icon {
+.main-navigation ul a > .icon {
 	display: none;
 }
 


### PR DESCRIPTION
Redo of #351: 

The 'scroll down' arrow is no longer hidden on small screens. Looks like one selector was made more specific, but not the other.

It looked like this:

![image](https://cldup.com/jWVwsbvn3x-3000x3000.png)

This PR should fix it.
