### PR TITLE
Increasing white space around .wrap element

### DIFF
--- a/style.css
+++ b/style.css
@@ -1217,8 +1217,8 @@ a:hover .nav-title,
 }
 
 .navigation-top .wrap {
+	max-width: 1000px;
 	padding: 0;
-	max-width: calc( 1000px + 2.5em);
 }
 
 .navigation-top a {
@@ -1259,7 +1259,7 @@ a:hover .nav-title,
 
 .main-navigation > div > ul {
 	border-top: 1px solid #eee;
-	padding: 0.75em 1.5em;
+	padding: 0.75em 3.375em;
 }
 
 .js .main-navigation.toggled-on > div > ul {
@@ -1421,8 +1421,8 @@ body {
 	margin-left: auto;
 	margin-right: auto;
 	max-width: 700px;
-	padding-left: 2em;
-	padding-right: 2em;
+	padding-left: 3em;
+	padding-right: 3em;
 }
 
 .wrap:after {
@@ -3000,8 +3000,8 @@ article.panel-placeholder {
 
 	.navigation-top .wrap {
 		max-width: 1000px;
-		/* The font size is 14px here and we need 32px padding in ems */
-		padding: 0.75em 2.2857142857em;
+		/* The font size is 14px here and we need 50px padding in ems */
+		padding: 0.75em 3.4166666666667em;
 	}
 
 	.navigation-top nav {
@@ -3585,15 +3585,9 @@ article.panel-placeholder {
 
 	/* Layout */
 
-	.wrap {
-		padding-left: 0;
-		padding-right: 0;
-	}
-
 	/* Navigation */
 	.navigation-top .wrap {
-		padding: 0.75em 0;
-		max-width: calc( 1000px + 2.5em);
+		padding: 0.75em 2.0em;
 	}
 
 	.navigation-top nav {


### PR DESCRIPTION
Fixes #195.

Increased white space around `.wrap` element, to move site content further away from the edge (especially the content that sticks out of the content container, like the comment avatars). 

Where the padding was 2.0em, also increased it to 3.0em.
