### PR TITLE
Adding space between social icons and footer border

### DIFF
--- a/style.css
+++ b/style.css
@@ -1988,11 +1988,15 @@ body:not(.twentyseventeen-front-page) .entry-header {
 	padding: 0 0 1.5em;
 }
 
+.site-footer .wrap {
+	padding-top: 2em;
+}
+
 /* Footer widgets */
 
 .site-footer .widget-area {
 	padding-bottom: 2em;
-	padding-top: 4em;
+	padding-top: 2em;
 }
 
 /* Social nav */


### PR DESCRIPTION
Fixes #304.

Moved some of the padding above the footer widgets to the footer wrap. That way, when there are no footer widgets, the social icons and site info don't bump into the top border.
