### PR TITLE
Remove extra space in dark theme & custom colors selectors

### DIFF
--- a/assets/css/colors-dark.css
+++ b/assets/css/colors-dark.css
@@ -263,8 +263,7 @@ body.colors-dark,
 }
 
 .colors-dark .entry-footer .cat-links:before,
-.colors-dark .entry-footer .tags-links:before,
-.colors-dark.twentyseventeen-front-page:not(.no-header-image) .site-description {
+.colors-dark .entry-footer .tags-links:before {
 	color: #555;
 }
 
@@ -389,8 +388,6 @@ body.colors-dark,
 .colors-dark .widget .widget-title a:hover,
 .colors-dark .widget ul li a:focus,
 .colors-dark .widget ul li a:hover,
-.colors-dark.twentyseventeen-front-page:not(.no-header-image) .site-title,
-.colors-dark.twentyseventeen-front-page:not(.no-header-image) .site-title a,
 .colors-dark button,
 .colors-dark input[type="button"],
 .colors-dark input[type="submit"],
@@ -401,8 +398,7 @@ body.colors-dark,
 
 body.colors-dark,
 .colors-dark .navigation-top,
-.colors-dark .main-navigation ul,
-.colors-dark.twentyseventeen-customizer.twentyseventeen-front-page .twentyseventeen-panel .twentyseventeen-panel-title {
+.colors-dark .main-navigation ul {
 	background: #222;
 }
 

--- a/assets/css/colors-dark.css
+++ b/assets/css/colors-dark.css
@@ -43,7 +43,7 @@
 .colors-dark .menu-toggle,
 .colors-dark .page .panel-content .entry-title,
 .colors-dark .page-title,
-.colors-dark body.page:not(.twentyseventeen-front-page) .entry-title,
+.colors-dark.page:not(.twentyseventeen-front-page) .entry-title,
 .colors-dark .page-links a .page-number,
 .colors-dark .comment-metadata a.comment-edit-link,
 .colors-dark .comment-reply-link:before,
@@ -62,7 +62,7 @@ body.colors-dark,
 .colors-dark h6,
 .colors-dark label,
 .colors-dark .entry-title a,
-.colors-dark .twentyseventeen-front-page .panel-content .recent-posts article,
+.colors-dark.twentyseventeen-front-page .panel-content .recent-posts article,
 .colors-dark .entry-footer .cat-links a,
 .colors-dark .entry-footer .tags-links a,
 .colors-dark .format-quote blockquote,
@@ -264,7 +264,7 @@ body.colors-dark,
 
 .colors-dark .entry-footer .cat-links:before,
 .colors-dark .entry-footer .tags-links:before,
-.colors-dark .twentyseventeen-front-page:not(.no-header-image) .site-description {
+.colors-dark.twentyseventeen-front-page:not(.no-header-image) .site-description {
 	color: #555;
 }
 
@@ -284,7 +284,7 @@ body.colors-dark,
 	border-color: #444;
 }
 
-.colors-dark .twentyseventeen-front-page article:not(.has-post-thumbnail):not(:first-child),
+.colors-dark.twentyseventeen-front-page article:not(.has-post-thumbnail):not(:first-child),
 .colors-dark .widget ul li {
 	border-top-color: #444;
 }
@@ -389,8 +389,8 @@ body.colors-dark,
 .colors-dark .widget .widget-title a:hover,
 .colors-dark .widget ul li a:focus,
 .colors-dark .widget ul li a:hover,
-.colors-dark .twentyseventeen-front-page:not(.no-header-image) .site-title,
-.colors-dark .twentyseventeen-front-page:not(.no-header-image) .site-title a,
+.colors-dark.twentyseventeen-front-page:not(.no-header-image) .site-title,
+.colors-dark.twentyseventeen-front-page:not(.no-header-image) .site-title a,
 .colors-dark button,
 .colors-dark input[type="button"],
 .colors-dark input[type="submit"],
@@ -402,7 +402,7 @@ body.colors-dark,
 body.colors-dark,
 .colors-dark .navigation-top,
 .colors-dark .main-navigation ul,
-.colors-dark .twentyseventeen-customizer.twentyseventeen-front-page .twentyseventeen-panel .twentyseventeen-panel-title {
+.colors-dark.twentyseventeen-customizer.twentyseventeen-front-page .twentyseventeen-panel .twentyseventeen-panel-title {
 	background: #222;
 }
 

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -279,8 +279,7 @@ body.colors-custom,
 }
 
 .colors-custom .entry-footer .cat-links:before,
-.colors-custom .entry-footer .tags-links:before,
-.colors-custom.twentyseventeen-front-page:not(.no-header-image) .site-description {
+.colors-custom .entry-footer .tags-links:before {
 	color: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 73% ); /* base: #bbb; */
 }
 
@@ -387,8 +386,6 @@ body.colors-custom,
 .colors-custom .widget .widget-title a:hover,
 .colors-custom .widget ul li a:focus,
 .colors-custom .widget ul li a:hover,
-.colors-custom.twentyseventeen-front-page:not(.no-header-image) .site-title,
-.colors-custom.twentyseventeen-front-page:not(.no-header-image) .site-title a,
 .colors-custom button,
 .colors-custom input[type="button"],
 .colors-custom input[type="submit"],
@@ -400,8 +397,7 @@ body.colors-custom,
 
 body.colors-custom,
 .colors-custom .navigation-top,
-.colors-custom .main-navigation ul,
-.colors-custom.twentyseventeen-customizer.twentyseventeen-front-page .twentyseventeen-panel .twentyseventeen-panel-title {
+.colors-custom .main-navigation ul {
 	background: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 100% ); /* base: #fff; */
 }
 

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -59,7 +59,7 @@ function twentyseventeen_custom_colors_css() {
 .colors-custom .menu-toggle,
 .colors-custom .page .panel-content .entry-title,
 .colors-custom .page-title,
-.colors-custom body.page:not(.twentyseventeen-front-page) .entry-title,
+.colors-custom.page:not(.twentyseventeen-front-page) .entry-title,
 .colors-custom .page-links a .page-number,
 .colors-custom .comment-metadata a.comment-edit-link,
 .colors-custom .comment-reply-link:before,
@@ -78,7 +78,7 @@ body.colors-custom,
 .colors-custom h6,
 .colors-custom label,
 .colors-custom .entry-title a,
-.colors-custom .twentyseventeen-front-page .panel-content .recent-posts article,
+.colors-custom.twentyseventeen-front-page .panel-content .recent-posts article,
 .colors-custom .entry-footer .cat-links a,
 .colors-custom .entry-footer .tags-links a,
 .colors-custom .format-quote blockquote,
@@ -280,7 +280,7 @@ body.colors-custom,
 
 .colors-custom .entry-footer .cat-links:before,
 .colors-custom .entry-footer .tags-links:before,
-.colors-custom .twentyseventeen-front-page:not(.no-header-image) .site-description {
+.colors-custom.twentyseventeen-front-page:not(.no-header-image) .site-description {
 	color: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 73% ); /* base: #bbb; */
 }
 
@@ -300,7 +300,7 @@ body.colors-custom,
 	border-color: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 87% ); /* base: #ddd; */
 }
 
-.colors-custom .twentyseventeen-front-page article:not(.has-post-thumbnail):not(:first-child),
+.colors-custom.twentyseventeen-front-page article:not(.has-post-thumbnail):not(:first-child),
 .colors-custom .widget ul li {
 	border-top-color: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 87% ); /* base: #ddd; */
 }
@@ -387,8 +387,8 @@ body.colors-custom,
 .colors-custom .widget .widget-title a:hover,
 .colors-custom .widget ul li a:focus,
 .colors-custom .widget ul li a:hover,
-.colors-custom .twentyseventeen-front-page:not(.no-header-image) .site-title,
-.colors-custom .twentyseventeen-front-page:not(.no-header-image) .site-title a,
+.colors-custom.twentyseventeen-front-page:not(.no-header-image) .site-title,
+.colors-custom.twentyseventeen-front-page:not(.no-header-image) .site-title a,
 .colors-custom button,
 .colors-custom input[type="button"],
 .colors-custom input[type="submit"],
@@ -401,7 +401,7 @@ body.colors-custom,
 body.colors-custom,
 .colors-custom .navigation-top,
 .colors-custom .main-navigation ul,
-.colors-custom .twentyseventeen-customizer.twentyseventeen-front-page .twentyseventeen-panel .twentyseventeen-panel-title {
+.colors-custom.twentyseventeen-customizer.twentyseventeen-front-page .twentyseventeen-panel .twentyseventeen-panel-title {
 	background: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 100% ); /* base: #fff; */
 }
 


### PR DESCRIPTION
There are a few body-level selectors prefixed with `.colors-dark` and `.colors-custom`, but these are also on the body tag. You can see the issue with page titles in the dark scheme-- they're invisible 😄

I started by just removing the space, but some of the selectors are actually wrong — we don't want to change the site title/tagline on images, and coloring the panel title in the customizer makes it less visible (IMO). So I've also removed those.
