### PR TITLE
Fix site info alignment when there is no social menu

### DIFF
--- a/style.css
+++ b/style.css
@@ -3654,7 +3654,6 @@ article.panel-placeholder {
 
 	.site-info {
 		float: left;
-		margin-left: 6%;
 		padding: 0.5em 0 0;
 		width: 58%;
 	}

--- a/style.css
+++ b/style.css
@@ -3658,6 +3658,10 @@ article.panel-placeholder {
 		width: 58%;
 	}
 
+	.social-navigation + .site-info {
+		margin-left: 6%;
+	}
+
 	.site-info .sep {
 		margin: 0 0.5em;
 		display: inline;


### PR DESCRIPTION
Fixes #340, building off #342. The 6% margin should only appear when there is a social menu.

Screenshots of PR:

![screen shot 2016-10-17 at 5 28 29 pm](https://cloud.githubusercontent.com/assets/541093/19456396/3b1b8f5e-948f-11e6-8ed8-55353db6f53a.png)
![screen shot 2016-10-17 at 5 28 05 pm](https://cloud.githubusercontent.com/assets/541093/19456395/3b1a0012-948f-11e6-934c-c472fc6fd026.png)
