### PR TITLE
Moving edit link on pages up by page title

### DIFF
--- a/components/page/content-page.php
+++ b/components/page/content-page.php
@@ -15,6 +15,7 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<header class="entry-header">
 		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+		<?php twentyseventeen_edit_link( get_the_ID() ); ?>
 	</header><!-- .entry-header -->
 	<div class="entry-content">
 		<?php
@@ -26,7 +27,4 @@
 			) );
 		?>
 	</div><!-- .entry-content -->
-	<footer class="entry-footer">
-		<?php twentyseventeen_edit_link( get_the_ID() ); ?>
-	</footer><!-- .entry-footer -->
 </article><!-- #post-## -->

--- a/style.css
+++ b/style.css
@@ -1591,7 +1591,8 @@ body:not(.title-tagline-hidden) .site-branding-text {
 }
 
 .twentyseventeen-panel .entry-header .edit-link {
-	font-size: 85%;
+	font-size: 14px;
+	font-size: 0.875rem;
 }
 
 /* Front Page - Recent Posts */
@@ -1981,7 +1982,8 @@ body:not(.twentyseventeen-front-page) .entry-header {
 }
 
 .page .entry-header .edit-link {
-	font-size: 85%;
+	font-size: 14px;
+	font-size: 0.875rem;
 }
 
 .page-links {

--- a/style.css
+++ b/style.css
@@ -1980,6 +1980,10 @@ body:not(.twentyseventeen-front-page) .entry-header {
 	padding-bottom: 2em;
 }
 
+.page .entry-header .edit-link {
+	font-size: 85%;
+}
+
 .page-links {
 	clear: both;
 	margin: 0 0 1.5em;


### PR DESCRIPTION
Moving edit link on pages up by page title.

Pages don't otherwise have post meta, and it lines up with the edit links on the front page. 

Fixes #250.
