### PR TITLE
Update color schemes for SVG icons, other fixes

### DIFF
--- a/assets/css/colors-dark.css
+++ b/assets/css/colors-dark.css
@@ -46,7 +46,7 @@
 .colors-dark.page:not(.twentyseventeen-front-page) .entry-title,
 .colors-dark .page-links a .page-number,
 .colors-dark .comment-metadata a.comment-edit-link,
-.colors-dark .comment-reply-link:before,
+.colors-dark .comment-reply-link .icon,
 .colors-dark h2.widget-title,
 .colors-dark mark {
 	color: #fff;
@@ -230,7 +230,7 @@ body.colors-dark,
 .colors-dark input[type="reset"].secondary:focus,
 .colors-dark input[type="submit"].secondary:hover,
 .colors-dark input[type="submit"].secondary:focus,
-.colors-dark .social-navigation a:before, /* @todo this needs higher contrast by default */
+.colors-dark .social-navigation a,
 .colors-dark hr {
 	background: #555;
 }
@@ -262,9 +262,9 @@ body.colors-dark,
 	border-color: #555;
 }
 
-.colors-dark .entry-footer .cat-links:before,
-.colors-dark .entry-footer .tags-links:before {
-	color: #555;
+.colors-dark .entry-footer .cat-links .icon,
+.colors-dark .entry-footer .tags-links .icon {
+	color: #666;
 }
 
 .colors-dark button.secondary,
@@ -391,8 +391,7 @@ body.colors-dark,
 .colors-dark button,
 .colors-dark input[type="button"],
 .colors-dark input[type="submit"],
-.colors-dark .entry-footer .edit-link a.post-edit-link,
-.colors-dark .bypostauthor > .comment-body > .comment-meta > .comment-author:before {
+.colors-dark .entry-footer .edit-link a.post-edit-link {
 	color: #222;
 }
 
@@ -419,8 +418,8 @@ body.colors-dark,
 
 @media screen and (min-width: 48em) {
 
-	.colors-dark .nav-links .nav-previous .nav-title:before,
-	.colors-dark .nav-links .nav-next .nav-title:after {
+	.colors-dark .nav-links .nav-previous .nav-title .icon,
+	.colors-dark .nav-links .nav-next .nav-title .icon {
 		color: #eee;
 	}
 

--- a/assets/css/colors-dark.css
+++ b/assets/css/colors-dark.css
@@ -434,17 +434,16 @@ body.colors-dark,
 
 	.colors-dark .main-navigation ul ul {
 		border-color: #333;
-	}
-
-	.colors-dark .main-navigation ul ul:before {
-		border-bottom-color: #333;
-	}
-
-	.colors-dark .main-navigation ul ul {
 		background: #222;
 	}
 
-	.colors-dark .main-navigation ul ul:after {
+	.colors-dark .main-navigation ul li.menu-item-has-children:before,
+	.colors-dark .main-navigation ul li.page_item_has_children:before {
+		border-bottom-color: #333;
+	}
+
+	.main-navigation ul li.menu-item-has-children:after,
+	.main-navigation ul li.page_item_has_children:after {
 		border-bottom-color: #222;
 	}
 

--- a/assets/css/colors-dark.css
+++ b/assets/css/colors-dark.css
@@ -199,10 +199,14 @@ body.colors-dark,
 .colors-dark .widget ul li a:focus,
 .colors-dark .widget ul li a:hover,
 .colors-dark .entry-footer .edit-link a.post-edit-link:hover,
-.colors-dark .entry-footer .edit-link a.post-edit-link:focus,
-.colors-dark .social-navigation a:hover:before,
-.colors-dark .social-navigation a:focus:before {
+.colors-dark .entry-footer .edit-link a.post-edit-link:focus {
 	background: #bbb;
+}
+
+.colors-dark .social-navigation a:hover,
+.colors-dark .social-navigation a:focus {
+	background: #999;
+	color: #222;
 }
 
 .colors-dark .entry-content a,

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -62,7 +62,7 @@ function twentyseventeen_custom_colors_css() {
 .colors-custom.page:not(.twentyseventeen-front-page) .entry-title,
 .colors-custom .page-links a .page-number,
 .colors-custom .comment-metadata a.comment-edit-link,
-.colors-custom .comment-reply-link:before,
+.colors-custom .comment-reply-link .icon,
 .colors-custom h2.widget-title,
 .colors-custom mark {
 	color: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 13% ); /* base: #222; */
@@ -246,7 +246,7 @@ body.colors-custom,
 .colors-custom input[type="reset"].secondary:focus,
 .colors-custom input[type="submit"].secondary:hover,
 .colors-custom input[type="submit"].secondary:focus,
-.colors-custom .social-navigation a:before, /* @todo this needs higher contrast by default */
+.colors-custom .social-navigation a,
 .colors-custom hr {
 	background: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 73% ); /* base: #bbb; */
 }
@@ -278,8 +278,8 @@ body.colors-custom,
 	border-color: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 73% ); /* base: #bbb; */
 }
 
-.colors-custom .entry-footer .cat-links:before,
-.colors-custom .entry-footer .tags-links:before {
+.colors-custom .entry-footer .cat-links .icon,
+.colors-custom .entry-footer .tags-links .icon {
 	color: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 73% ); /* base: #bbb; */
 }
 
@@ -390,7 +390,6 @@ body.colors-custom,
 .colors-custom input[type="button"],
 .colors-custom input[type="submit"],
 .colors-custom .entry-footer .edit-link a.post-edit-link,
-.colors-custom .bypostauthor > .comment-body > .comment-meta > .comment-author:before,
 .colors-custom .social-navigation a:before {
 	color: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 100% ); /* base: #fff; */
 }
@@ -418,8 +417,8 @@ body.colors-custom,
 
 @media screen and (min-width: 48em) {
 
-	.colors-custom .nav-links .nav-previous .nav-title:before,
-	.colors-custom .nav-links .nav-next .nav-title:after {
+	.colors-custom .nav-links .nav-previous .nav-title .icon,
+	.colors-custom .nav-links .nav-next .nav-title .icon {
 		color: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 20% ); /* base: #222; */
 	}
 

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -433,17 +433,16 @@ body.colors-custom,
 
 	.colors-custom .main-navigation ul ul {
 		border-color: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 93% ); /* base: #eee; */
-	}
-
-	.colors-custom .main-navigation ul ul:before {
-		border-bottom-color: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 93% ); /* base: #eee; */
-	}
-
-	.colors-custom .main-navigation ul ul {
 		background: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 100% ); /* base: #fff; */
 	}
 
-	.colors-custom .main-navigation ul ul:after {
+	.colors-custom .main-navigation ul li.menu-item-has-children:before,
+	.colors-custom .main-navigation ul li.page_item_has_children:before {
+		border-bottom-color: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 93% ); /* base: #eee; */
+	}
+
+	.colors-custom .main-navigation ul li.menu-item-has-children:after,
+	.colors-custom .main-navigation ul li.page_item_has_children:after {
 		border-bottom-color: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 100% ); /* base: #fff; */
 	}
 

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -216,8 +216,8 @@ body.colors-custom,
 .colors-custom .widget ul li a:hover,
 .colors-custom .entry-footer .edit-link a.post-edit-link:hover,
 .colors-custom .entry-footer .edit-link a.post-edit-link:focus,
-.colors-custom .social-navigation a:hover:before,
-.colors-custom .social-navigation a:focus:before {
+.colors-custom .social-navigation a:hover,
+.colors-custom .social-navigation a:focus {
 	background: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 46% ); /* base: #767676; */
 }
 
@@ -390,7 +390,7 @@ body.colors-custom,
 .colors-custom input[type="button"],
 .colors-custom input[type="submit"],
 .colors-custom .entry-footer .edit-link a.post-edit-link,
-.colors-custom .social-navigation a:before {
+.colors-custom .social-navigation a {
 	color: hsl( ' . esc_attr( $hue ) . ', ' . esc_attr( $saturation ) . ', 100% ); /* base: #fff; */
 }
 


### PR DESCRIPTION
I noticed a few places where the alternate color schemes (dark and custom) were a little out-of-sync. This PR:
- Updates both color schemes to color new SVG icons
- Updates menu dropdown arrow (the one pointing up to the parent item) to correct colors
- Updates social menu icons & hover/focus states
