### PR TITLE
Fixing spacing around, and above and below social navigation icons

### DIFF
--- a/rtl.css
+++ b/rtl.css
@@ -225,7 +225,8 @@ input[type="checkbox"] {
 /* Footer */
 
 .social-navigation a {
-	margin: 0 0 0 1em;
+	margin-left: 1em;
+	margin-right: 0;
 }
 
 /* Customizer styles */
@@ -476,6 +477,9 @@ input[type="checkbox"] {
 
 	.site-info {
 		float: right;
+	}
+
+	.social-navigation + .site-info {
 		margin-left: 0;
 		margin-right: 6%;
 	}

--- a/style.css
+++ b/style.css
@@ -2006,10 +2006,10 @@ body:not(.twentyseventeen-front-page) .entry-header {
 
 .site-footer {
 	border-top: 1px solid #eee;
-	padding: 0 0 1.5em;
 }
 
 .site-footer .wrap {
+	padding-bottom: 1.5em;
 	padding-top: 2em;
 }
 
@@ -2044,7 +2044,7 @@ body:not(.twentyseventeen-front-page) .entry-header {
 	color: #fff;
 	display: inline-block;
 	height: 40px;
-	margin: 0 1em 0 0;
+	margin: 0 1em 0.5em 0;
 	text-align: center;
 	width: 40px;
 }
@@ -2066,6 +2066,7 @@ body:not(.twentyseventeen-front-page) .entry-header {
 .site-info {
 	font-size: 14px;
 	font-size: 0.875rem;
+	margin-bottom: 1.0em;
 }
 
 .site-info a {
@@ -3677,12 +3678,13 @@ article.panel-placeholder {
 	.social-navigation {
 		clear: left;
 		float: left;
+		margin-bottom: 0;
 		width: 36%;
 	}
 
 	.site-info {
 		float: left;
-		padding: 0.5em 0 0;
+		padding: 0.7em 0 0;
 		width: 58%;
 	}
 


### PR DESCRIPTION
Fixing spacing around, and above and below social navigation icons

Also added RTL styles for the 'site-info' alone issue. Replacement for #427.
