### PR TITLE
Add One Column layout to front page

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -45,7 +45,7 @@ function twentyseventeen_body_classes( $classes ) {
 	}
 
 	// Add class for one or two column page layouts.
-	if ( is_page() && ! twentyseventeen_is_frontpage() && ! is_home() ) {
+	if ( is_page() ) {
 		if ( 'one-column' === get_theme_mod( 'page_options' ) ) {
 			$classes[] = 'page-one-column';
 		} else {
@@ -95,7 +95,7 @@ function twentyseventeen_is_frontpage() {
  * Custom Active Callback to check for page.
  */
 function twentyseventeen_is_page() {
-	return ( is_page() && ! twentyseventeen_is_frontpage() );
+	return ( is_page() );
 }
 
 /**

--- a/rtl.css
+++ b/rtl.css
@@ -336,17 +336,17 @@ input[type="checkbox"] {
 
 	/* Front Page */
 
-	.panel-content .entry-header {
+	.page-two-column .panel-content .entry-header {
 		float: right;
 	}
 
-	.panel-content .entry-content {
+	.page-two-column .panel-content .entry-content {
 		float: left;
 	}
 
 	/* Front Page - Recent Posts */
 
-	.panel-content .recent-posts {
+	.page-two-column .panel-content .recent-posts {
 		clear: left;
 		float: left;
 	}
@@ -401,7 +401,7 @@ input[type="checkbox"] {
 	/* blog index and archive */
 
 	.blog:not(.has-sidebar) .entry-content blockquote.alignleft,
-	.twentyseventeen-front-page .entry-content blockquote.alignleft,
+	.twentyseventeen-front-page.page-two-column .entry-content blockquote.alignleft,
 	.archive:not(.has-sidebar) .entry-content blockquote.alignleft,
 	.page-two-column .entry-content blockquote.alignleft {
 		margin-left: 0;
@@ -409,7 +409,7 @@ input[type="checkbox"] {
 	}
 
 	.blog:not(.has-sidebar) .entry-content blockquote.alignright,
-	.twentyseventeen-front-page #primary .entry-content blockquote.alignright,
+	.twentyseventeen-front-page.page-two-column #primary .entry-content blockquote.alignright,
 	.archive:not(.has-sidebar) .entry-content blockquote.alignright,
 	.page-two-column #primary .entry-content blockquote.alignright {
 		margin-right: -72.5%;

--- a/style.css
+++ b/style.css
@@ -1825,7 +1825,7 @@ body:not(.twentyseventeen-front-page) .entry-header {
 /* Single Post */
 
 .single-post:not(.has-sidebar) #primary,
-.page.page-one-column #primary {
+.page.page-one-column:not(.twentyseventeen-front-page) #primary {
 	margin-left: auto;
 	margin-right: auto;
 	max-width: 740px;
@@ -3029,6 +3029,10 @@ article.panel-placeholder {
 		padding-top: 3.5em;
 	}
 
+	.page-one-column .panel-content .wrap {
+		max-width: 740px;
+	}
+
 	.panel-content .entry-header {
 		margin-bottom: 4.5em;
 	}
@@ -3431,19 +3435,19 @@ article.panel-placeholder {
 		max-height: 1200px;
 	}
 
-	.panel-content .entry-header {
+	.page-two-column .panel-content .entry-header {
 		float: left;
 		width: 36%;
 	}
 
-	.panel-content .entry-content {
+	.page-two-column .panel-content .entry-content {
 		float: right;
 		width: 58%;
 	}
 
 	/* Front Page - Recent Posts */
 
-	.panel-content .recent-posts {
+	.page-two-column .panel-content .recent-posts {
 		clear: right;
 		float: right;
 		width: 58%;
@@ -3600,7 +3604,7 @@ article.panel-placeholder {
 	/* blog and archive */
 
 	.blog:not(.has-sidebar) .entry-content blockquote.alignleft,
-	.twentyseventeen-front-page .entry-content blockquote.alignleft,
+	.twentyseventeen-front-page.page-two-column .entry-content blockquote.alignleft,
 	.archive:not(.has-sidebar) .entry-content blockquote.alignleft,
 	.page-two-column .entry-content blockquote.alignleft {
 		margin-left: -72.5%;
@@ -3608,7 +3612,7 @@ article.panel-placeholder {
 	}
 
 	.blog:not(.has-sidebar) .entry-content blockquote.alignright,
-	.twentyseventeen-front-page .entry-content blockquote.alignright,
+	.twentyseventeen-front-page.page-two-column .entry-content blockquote.alignright,
 	.archive:not(.has-sidebar) .entry-content blockquote.alignright,
 	.page-two-column .entry-content blockquote.alignright {
 		margin-right: 0;


### PR DESCRIPTION
Updating styles and customizer settings, so the one-column/two-column options are applied to regular pages and the front page. 

Fixes #439.
