### PR TITLE
Nudge arrow position

### DIFF
--- a/style.css
+++ b/style.css
@@ -3387,10 +3387,10 @@ article.panel-placeholder {
 	.navigation-top .menu-scroll-down {
 		color: #767676;
 		display: block;
-		padding: 0.75em;
+		padding: 0.5em 0.5em 0.4em;
 		position: absolute;
 		right: 0;
-		top: 0.40em;
+		top: 0.9em;
 		-webkit-transform: rotate( 90deg ); /* Chrome, Safari, Opera */
 		-ms-transform: rotate( 90deg ); /* IE 9 */
 		transform: rotate( 90deg );


### PR DESCRIPTION
Move arrow down a hair more. Adjust padding around it, so it still appears visually centred when focused as well.

This will work if we want to vertically align the arrow to the top row of the menus, but if we want it to be vertically aligned against multiple levels of menu, we'll need a different approach. 

Fixes #446.
