### PR TITLE
Remove wp_nav_menu fallback

### DIFF
--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -134,7 +134,7 @@
 	$( document ).ready( function() {
 
 		// Let's fire some JavaScript!
-		if( twentyseventeenScreenReaderText.has_navigation === 'true' ) {
+		if ( 'true' === twentyseventeenScreenReaderText.has_navigation ) {
 
 			/**
 			 * 'Scroll Down' arrow in menu area
@@ -160,13 +160,13 @@
 		adjustHeaderHeight();
 		setQuotesIcon();
 		supportsInlineSVG();
-		
 		if ( true === supportsInlineSVG() ) {
 			document.documentElement.className = document.documentElement.className.replace( /(\s*)no-svg(\s*)/, '$1svg$2' );
 		}
 	} );
 
-	if( twentyseventeenScreenReaderText.has_navigation === 'true' ) {
+	if ( 'true' === twentyseventeenScreenReaderText.has_navigation ) {
+		
 		// On scroll, we want to stick/unstick the navigation
 		$( window ).on( 'scroll', function() {
 			adjustScrollClass();

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -166,7 +166,7 @@
 	} );
 
 	if ( 'true' === twentyseventeenScreenReaderText.has_navigation ) {
-		
+
 		// On scroll, we want to stick/unstick the navigation
 		$( window ).on( 'scroll', function() {
 			adjustScrollClass();

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -133,46 +133,55 @@
 	// Fires on document ready
 	$( document ).ready( function() {
 
-		/**
-		 * 'Scroll Down' arrow in menu area
-		 */
-		if ( $( 'body' ).hasClass( 'admin-bar' ) ) {
-			menuTop = -32;
-		}
-		if ( $( 'body' ).hasClass( 'blog' ) ) {
-			menuTop -= 30; // The div for latest posts has no space above content, add some to account for this
-		}
-		$menuScrollDown.click( function( e ) {
-			e.preventDefault();
-			$( window ).scrollTo( '#primary', {
-				duration: 600,
-				offset: { 'top': menuTop - navigationOuterHeight }
-			} );
-		} );
-
 		// Let's fire some JavaScript!
-		setNavProps();
-		adjustScrollClass();
+		if( twentyseventeenScreenReaderText.has_navigation === 'true' ) {
+
+			/**
+			 * 'Scroll Down' arrow in menu area
+			 */
+			if ( $( 'body' ).hasClass( 'admin-bar' ) ) {
+				menuTop = -32;
+			}
+			if ( $( 'body' ).hasClass( 'blog' ) ) {
+				menuTop -= 30; // The div for latest posts has no space above content, add some to account for this
+			}
+			$menuScrollDown.click( function( e ) {
+				e.preventDefault();
+				$( window ).scrollTo( '#primary', {
+					duration: 600,
+					offset: { 'top': menuTop - navigationOuterHeight }
+				} );
+			} );
+
+			setNavProps();
+			adjustScrollClass();
+		}
+
 		adjustHeaderHeight();
 		setQuotesIcon();
 		supportsInlineSVG();
+		
 		if ( true === supportsInlineSVG() ) {
 			document.documentElement.className = document.documentElement.className.replace( /(\s*)no-svg(\s*)/, '$1svg$2' );
 		}
 	} );
 
-	// On scroll, we want to stick/unstick the navigation
-	$( window ).on( 'scroll', function() {
-		adjustScrollClass();
-		adjustHeaderHeight();
-	} );
+	if( twentyseventeenScreenReaderText.has_navigation === 'true' ) {
+		// On scroll, we want to stick/unstick the navigation
+		$( window ).on( 'scroll', function() {
+			adjustScrollClass();
+			adjustHeaderHeight();
+		} );
 
-	// Also want to make sure the navigation is where it should be on resize
+		// Also want to make sure the navigation is where it should be on resize
+		$( window ).resize( function() {
+			setNavProps();
+			setTimeout( adjustScrollClass, 500 );
+			setTimeout( adjustHeaderHeight, 1000 );
+		} );
+	}
+
 	$( window ).resize( function() {
-		setNavProps();
-		setTimeout( adjustScrollClass, 500 );
-		setTimeout( adjustHeaderHeight, 1000 );
-
 		clearTimeout( resizeTimer );
 		resizeTimer = setTimeout( function() {
 			belowEntryMetaClass( 'blockquote.alignleft, blockquote.alignright' );

--- a/components/navigation/navigation-top.php
+++ b/components/navigation/navigation-top.php
@@ -14,7 +14,7 @@
 	<?php wp_nav_menu( array(
 		'theme_location' => 'top',
 		'menu_id'        => 'top-menu',
-		'fallback_cb'    => 'twentyseventeen_fallback_menu',
+		'fallback_cb'    => false,
 	) ); ?>
 
 	<?php if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) : ?>

--- a/components/navigation/navigation-top.php
+++ b/components/navigation/navigation-top.php
@@ -14,7 +14,6 @@
 	<?php wp_nav_menu( array(
 		'theme_location' => 'top',
 		'menu_id'        => 'top-menu',
-		'fallback_cb'    => false,
 	) ); ?>
 
 	<?php if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) : ?>

--- a/functions.php
+++ b/functions.php
@@ -264,16 +264,23 @@ function twentyseventeen_scripts() {
 
 	wp_enqueue_script( 'twentyseventeen-skip-link-focus-fix', get_theme_file_uri( '/assets/js/skip-link-focus-fix.js' ), array(), '1.0', true );
 
-	wp_enqueue_script( 'twentyseventeen-navigation', get_theme_file_uri( '/assets/js/navigation.js' ), array(), '1.0', true );
+	$twentyseventeenScreenReaderText = array( 
+		'quote'          => twentyseventeen_get_svg( array( 'icon' => 'quote-right' ) ),
+		'has_navigation' => 'false',
+	);
 
-	wp_localize_script( 'twentyseventeen-navigation', 'twentyseventeenScreenReaderText', array(
-		'expand'   => __( 'Expand child menu', 'twentyseventeen' ),
-		'collapse' => __( 'Collapse child menu', 'twentyseventeen' ),
-		'icon'     => twentyseventeen_get_svg( array( 'icon' => 'expand', 'fallback' => true ) ),
-		'quote'    => twentyseventeen_get_svg( array( 'icon' => 'quote-right' ) ),
-	) );
+	if ( has_nav_menu( 'top' ) ) {
+		wp_enqueue_script( 'twentyseventeen-navigation', get_theme_file_uri( '/assets/js/navigation.js' ), array(), '1.0', true );
+		
+		$twentyseventeenScreenReaderText['has_navigation'] = 'true';
+		$twentyseventeenScreenReaderText['expand']         = __( 'Expand child menu', 'twentyseventeen' );
+		$twentyseventeenScreenReaderText['collapse']       = __( 'Collapse child menu', 'twentyseventeen' );
+		$twentyseventeenScreenReaderText['icon']           = twentyseventeen_get_svg( array( 'icon' => 'expand', 'fallback' => true ) );
+	}
 
 	wp_enqueue_script( 'twentyseventeen-global', get_theme_file_uri( '/assets/js/global.js' ), array( 'jquery' ), '1.0', true );
+
+	wp_localize_script( 'twentyseventeen-skip-link-focus-fix', 'twentyseventeenScreenReaderText', $twentyseventeenScreenReaderText );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );

--- a/functions.php
+++ b/functions.php
@@ -264,23 +264,22 @@ function twentyseventeen_scripts() {
 
 	wp_enqueue_script( 'twentyseventeen-skip-link-focus-fix', get_theme_file_uri( '/assets/js/skip-link-focus-fix.js' ), array(), '1.0', true );
 
-	$twentyseventeenScreenReaderText = array( 
+	$twentyseventeen_l10n = array(
 		'quote'          => twentyseventeen_get_svg( array( 'icon' => 'quote-right' ) ),
 		'has_navigation' => 'false',
 	);
 
 	if ( has_nav_menu( 'top' ) ) {
 		wp_enqueue_script( 'twentyseventeen-navigation', get_theme_file_uri( '/assets/js/navigation.js' ), array(), '1.0', true );
-		
-		$twentyseventeenScreenReaderText['has_navigation'] = 'true';
-		$twentyseventeenScreenReaderText['expand']         = __( 'Expand child menu', 'twentyseventeen' );
-		$twentyseventeenScreenReaderText['collapse']       = __( 'Collapse child menu', 'twentyseventeen' );
-		$twentyseventeenScreenReaderText['icon']           = twentyseventeen_get_svg( array( 'icon' => 'expand', 'fallback' => true ) );
+		$twentyseventeen_l10n['has_navigation'] = 'true';
+		$twentyseventeen_l10n['expand']         = __( 'Expand child menu', 'twentyseventeen' );
+		$twentyseventeen_l10n['collapse']       = __( 'Collapse child menu', 'twentyseventeen' );
+		$twentyseventeen_l10n['icon']           = twentyseventeen_get_svg( array( 'icon' => 'expand', 'fallback' => true ) );
 	}
 
 	wp_enqueue_script( 'twentyseventeen-global', get_theme_file_uri( '/assets/js/global.js' ), array( 'jquery' ), '1.0', true );
 
-	wp_localize_script( 'twentyseventeen-skip-link-focus-fix', 'twentyseventeenScreenReaderText', $twentyseventeenScreenReaderText );
+	wp_localize_script( 'twentyseventeen-skip-link-focus-fix', 'twentyseventeenScreenReaderText', $twentyseventeen_l10n );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );

--- a/header.php
+++ b/header.php
@@ -30,11 +30,13 @@
 
 		<?php get_template_part( 'components/header/header', 'image' ); ?>
 
-		<div class="navigation-top">
-			<div class="wrap">
-				<?php get_template_part( 'components/navigation/navigation', 'top' ); ?>
-			</div><!-- .wrap -->
-		</div><!-- .navigation-top -->
+		<?php if( has_nav_menu( 'top' ) ) : ?>
+			<div class="navigation-top">
+				<div class="wrap">
+					<?php get_template_part( 'components/navigation/navigation', 'top' ); ?>
+				</div><!-- .wrap -->
+			</div><!-- .navigation-top -->
+		<?php endif; ?>
 
 	</header><!-- #masthead -->
 

--- a/header.php
+++ b/header.php
@@ -30,7 +30,7 @@
 
 		<?php get_template_part( 'components/header/header', 'image' ); ?>
 
-		<?php if( has_nav_menu( 'top' ) ) : ?>
+		<?php if ( has_nav_menu( 'top' ) ) : ?>
 			<div class="navigation-top">
 				<div class="wrap">
 					<?php get_template_part( 'components/navigation/navigation', 'top' ); ?>

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -101,12 +101,3 @@ function twentyseventeen_is_frontpage() {
 function twentyseventeen_is_page() {
 	return ( is_page() && ! twentyseventeen_is_frontpage() );
 }
-
-/**
- * Display a default list of pages if no menu is selected.
- */
-function twentyseventeen_fallback_menu() {
-	wp_page_menu( array(
-		'link_after' => twentyseventeen_get_svg( array( 'icon' => 'expand' ) ),
-	) );
-}


### PR DESCRIPTION
#425
- Sets wp_nav_menu fallback_cb to false
- Removes twentyseventeen_fallback_menu(), which isn't needed anymore
- Checks whether the 'top' theme_location has a menu assigned or not. If not - prevents any navigation menu markup from showing up.
