### PR TITLE
Turning off 'background-attachment: fixed' for iOS

### DIFF
--- a/style.css
+++ b/style.css
@@ -3751,16 +3751,21 @@ article.panel-placeholder {
 
 @media screen and ( min-width: 55em ) {
 
-	.custom-header-image {
-		background-attachment: fixed;
-	}
-
+	.custom-header-image,
 	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
-	.home.blog:not(.no-header-image) .custom-header-image {
+	.home.blog:not(.no-header-image) .custom-header-image,
+	.panel-image {
 		background-attachment: fixed;
 	}
 
-	.panel-image {
+	/* Overriding Safari-specific background-attachment value for non-iOS devices. */
+	_:-webkit-full-screen,
+	_::-webkit-full-page-media,
+	_:future,
+	:root .custom-header-image,
+	:root .twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
+	:root .home.blog:not(.no-header-image) .custom-header-image,
+	:root .panel-image {
 		background-attachment: fixed;
 	}
 }
@@ -3813,6 +3818,18 @@ article.panel-placeholder {
 	.admin-bar .site-navigation-fixed.navigation-top,
 	.admin-bar .site-navigation-hidden.navigation-top {
 		top: 46px;
+	}
+}
+
+/* Work around specifically for Safari; "fixed" causes display issues. Only needed for iOS, so is overridden for non-iOS devices. */
+@media screen and ( min-color-index: 0 ) and ( -webkit-min-device-pixel-ratio: 0 ) {
+	@media {
+		.custom-header-image,
+		.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
+		.home.blog:not(.no-header-image) .custom-header-image,
+		.panel-image {
+			background-attachment: scroll;
+		}
 	}
 }
 


### PR DESCRIPTION
Turning off the `background-attachment: fixed` style for iOS devices; it's not supported, and causes the images to be blown up to really huge, blurry sizes.

I steered away from sized-based `@media` queries, since iPad Pros are so large and it would cause the effect to be 'turned off' on laptop-sized screens, too. 

However, what I ended up with feels hacky to me - I'd be interested in suggestions others have for this. 

See #450.
