### PR TITLE
Check to make sure entry-footer isn't empty

### DIFF
--- a/components/post/content-audio.php
+++ b/components/post/content-audio.php
@@ -86,9 +86,7 @@
 	</div><!-- .entry-content -->
 
 	<?php if ( is_single() ) : ?>
-		<footer class="entry-footer">
-			<?php twentyseventeen_entry_footer(); ?>
-		</footer><!-- .entry-footer -->
+		<?php twentyseventeen_entry_footer(); ?>
 	<?php endif; ?>
 
 </article><!-- #post-## -->

--- a/components/post/content-gallery.php
+++ b/components/post/content-gallery.php
@@ -78,9 +78,7 @@
 	</div><!-- .entry-content -->
 
 	<?php if ( is_single() ) : ?>
-		<footer class="entry-footer">
-			<?php twentyseventeen_entry_footer(); ?>
-		</footer><!-- .entry-footer -->
+		<?php twentyseventeen_entry_footer(); ?>
 	<?php endif; ?>
 
 </article><!-- #post-## -->

--- a/components/post/content-image.php
+++ b/components/post/content-image.php
@@ -68,9 +68,7 @@
 	</div><!-- .entry-content -->
 
 	<?php if ( is_single() ) : ?>
-		<footer class="entry-footer">
-			<?php twentyseventeen_entry_footer(); ?>
-		</footer><!-- .entry-footer -->
+		<?php twentyseventeen_entry_footer(); ?>
 	<?php endif; ?>
 
 </article><!-- #post-## -->

--- a/components/post/content-video.php
+++ b/components/post/content-video.php
@@ -85,9 +85,7 @@
 	</div><!-- .entry-content -->
 
 	<?php if ( is_single() ) : ?>
-		<footer class="entry-footer">
-			<?php twentyseventeen_entry_footer(); ?>
-		</footer><!-- .entry-footer -->
+		<?php twentyseventeen_entry_footer(); ?>
 	<?php endif; ?>
 
 </article><!-- #post-## -->

--- a/components/post/content.php
+++ b/components/post/content.php
@@ -64,9 +64,7 @@
 	</div><!-- .entry-content -->
 
 	<?php if ( is_single() ) : ?>
-		<footer class="entry-footer">
-			<?php twentyseventeen_entry_footer(); ?>
-		</footer><!-- .entry-footer -->
+		<?php twentyseventeen_entry_footer(); ?>
 	<?php endif; ?>
 
 </article><!-- #post-## -->

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -59,26 +59,36 @@ function twentyseventeen_entry_footer() {
 	/* translators: used between list items, there is a space after the comma */
 	$separate_meta = __( ', ', 'twentyseventeen' );
 
-	if ( 'post' === get_post_type() ) {
-		echo '<span class="cat-tags-links">';
+	// Get Categories for posts.
+	$categories_list = get_the_category_list( $separate_meta );
 
-		// Display Categories for posts.
-		$categories_list = get_the_category_list( $separate_meta );
-		// Make sure there's more than one category before displaying.
-		if ( $categories_list && twentyseventeen_categorized_blog() ) {
-			echo '<span class="cat-links">' . twentyseventeen_get_svg( array( 'icon' => 'folder-open' ) ) . '<span class="screen-reader-text">' . __( 'Categories', 'twentyseventeen' ) . '</span>' . $categories_list . '</span>'; // WPCS: XSS OK.
-		}
+	// Get Tags for posts.
+	$tags_list = get_the_tag_list( '', $separate_meta );
 
-		// Display Tags for posts.
-		$tags_list = get_the_tag_list( '', $separate_meta );
-		if ( $tags_list ) {
-			echo '<span class="tags-links">' . twentyseventeen_get_svg( array( 'icon' => 'hashtag' ) ) . '<span class="screen-reader-text">' . __( 'Tags', 'twentyseventeen' ) . '</span>' . $tags_list . '</span>'; // WPCS: XSS OK.
-		}
+	// We don't want to output .entry-footer if it will be empty, so make sure its not.
+	if ( ( ( twentyseventeen_categorized_blog() && $categories_list ) || $tags_list ) || get_edit_post_link() ) {
 
-		echo '</span>';
+		echo '<footer class="entry-footer">';
+
+			if ( 'post' === get_post_type() ) {
+				echo '<span class="cat-tags-links">';
+
+					// Make sure there's more than one category before displaying.
+					if ( $categories_list && twentyseventeen_categorized_blog() ) {
+						echo '<span class="cat-links">' . twentyseventeen_get_svg( array( 'icon' => 'folder-open' ) ) . '<span class="screen-reader-text">' . __( 'Categories', 'twentyseventeen' ) . '</span>' . $categories_list . '</span>'; // WPCS: XSS OK.
+					}
+
+					if ( $tags_list ) {
+						echo '<span class="tags-links">' . twentyseventeen_get_svg( array( 'icon' => 'hashtag' ) ) . '<span class="screen-reader-text">' . __( 'Tags', 'twentyseventeen' ) . '</span>' . $tags_list . '</span>'; // WPCS: XSS OK.
+					}
+
+				echo '</span>';
+			}
+
+			twentyseventeen_edit_link();
+
+		echo '</footer> <!-- .entry-footer -->';
 	}
-
-	twentyseventeen_edit_link();
 }
 endif;
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -59,32 +59,38 @@ function twentyseventeen_entry_footer() {
 	/* translators: used between list items, there is a space after the comma */
 	$separate_meta = __( ', ', 'twentyseventeen' );
 
-	if ( 'post' === get_post_type() ) {
+	// Get Categories for posts.
+	$categories_list = get_the_category_list( $separate_meta );
 
-		// Get Categories for posts.
-		$categories_list = get_the_category_list( $separate_meta );
+	// Get Tags for posts.
+	$tags_list = get_the_tag_list( '', $separate_meta );
 
-		// Display Tags for posts.
-		$tags_list = get_the_tag_list( '', $separate_meta );
+	// We don't want to output .entry-footer if it will be empty, so make sure its not.
+	if ( ( ( twentyseventeen_categorized_blog() && $categories_list ) || $tags_list ) || get_edit_post_link() ) {
 
-		// Make sure we have one or the other before proceeding.
-		if ( ( $categories_list && twentyseventeen_categorized_blog() ) || $tags_list ) {
-			echo '<span class="cat-tags-links">';
+		echo '<footer class="entry-footer">';
 
-			// Make sure there's more than one category before displaying.
-			if ( $categories_list && twentyseventeen_categorized_blog() ) {
-				echo '<span class="cat-links">' . twentyseventeen_get_svg( array( 'icon' => 'folder-open' ) ) . '<span class="screen-reader-text">' . __( 'Categories', 'twentyseventeen' ) . '</span>' . $categories_list . '</span>'; // WPCS: XSS OK.
+			if ( 'post' === get_post_type() ) {
+				if ( ( $categories_list && twentyseventeen_categorized_blog() ) || $tags_list ) {
+					echo '<span class="cat-tags-links">';
+
+						// Make sure there's more than one category before displaying.
+						if ( $categories_list && twentyseventeen_categorized_blog() ) {
+							echo '<span class="cat-links">' . twentyseventeen_get_svg( array( 'icon' => 'folder-open' ) ) . '<span class="screen-reader-text">' . __( 'Categories', 'twentyseventeen' ) . '</span>' . $categories_list . '</span>'; // WPCS: XSS OK.
+						}
+
+						if ( $tags_list ) {
+							echo '<span class="tags-links">' . twentyseventeen_get_svg( array( 'icon' => 'hashtag' ) ) . '<span class="screen-reader-text">' . __( 'Tags', 'twentyseventeen' ) . '</span>' . $tags_list . '</span>'; // WPCS: XSS OK.
+						}
+
+					echo '</span>';
+				}
 			}
 
-			if ( $tags_list ) {
-				echo '<span class="tags-links">' . twentyseventeen_get_svg( array( 'icon' => 'hashtag' ) ) . '<span class="screen-reader-text">' . __( 'Tags', 'twentyseventeen' ) . '</span>' . $tags_list . '</span>'; // WPCS: XSS OK.
-			}
+			twentyseventeen_edit_link();
 
-			echo '</span>';
-		}
+		echo '</footer> <!-- .entry-footer -->';
 	}
-
-	twentyseventeen_edit_link();
 }
 endif;
 


### PR DESCRIPTION
Adding a check to make sure `.entry-footer` will actually have stuff in it before writing it to the page, so we don't end up with an empty bordered space.

Fixes #314.
