### PR TITLE
Move `<span class="screen-reader-text">` for post titles in links.

### DIFF
--- a/components/page/content-front-page-panels.php
+++ b/components/page/content-front-page-panels.php
@@ -48,8 +48,8 @@ global $twentyseventeencounter;
 				<?php
 					/* translators: %s: Name of current post */
 					the_content( sprintf(
-						__( 'Continue reading %s', 'twentyseventeen' ),
-						the_title( '<span class="screen-reader-text">"', '"</span>', false )
+						__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'twentyseventeen' ),
+						get_the_title()
 					) );
 				?>
 			</div><!-- .entry-content -->

--- a/components/page/content-front-page.php
+++ b/components/page/content-front-page.php
@@ -24,8 +24,8 @@
 				<?php
 					/* translators: %s: Name of current post */
 					the_content( sprintf(
-						__( 'Continue reading %s', 'twentyseventeen' ),
-						the_title( '<span class="screen-reader-text">"', '"</span>', false )
+						__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'twentyseventeen' ),
+						get_the_title()
 					) );
 				?>
 			</div><!-- .entry-content -->

--- a/components/post/content-audio.php
+++ b/components/post/content-audio.php
@@ -68,10 +68,10 @@
 
 		if ( is_single() || empty( $audio ) ) :
 
+			/* translators: %s: Name of current post */
 			the_content( sprintf(
-				/* translators: %s: Name of current post */
-				__( 'Continue reading %s', 'twentyseventeen' ),
-				the_title( '<span class="screen-reader-text">"', '"</span>', false )
+				__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'twentyseventeen' ),
+				get_the_title()
 			) );
 
 			wp_link_pages( array(

--- a/components/post/content-gallery.php
+++ b/components/post/content-gallery.php
@@ -60,10 +60,10 @@
 
 		if ( is_single() || ! get_post_gallery() ) :
 
+			/* translators: %s: Name of current post */
 			the_content( sprintf(
-				/* translators: %s: Name of current post */
-				__( 'Continue reading %s', 'twentyseventeen' ),
-				the_title( '<span class="screen-reader-text">"', '"</span>', false )
+				__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'twentyseventeen' ),
+				get_the_title()
 			) );
 
 			wp_link_pages( array(

--- a/components/post/content-image.php
+++ b/components/post/content-image.php
@@ -50,10 +50,10 @@
 		<?php if ( is_single() || '' === get_the_post_thumbnail() ) :
 
 			// Only show content if is a single post, or if there's no featured image.
+			/* translators: %s: Name of current post */
 			the_content( sprintf(
-				/* translators: %s: Name of current post */
-				__( 'Continue reading %s', 'twentyseventeen' ),
-				the_title( '<span class="screen-reader-text">"', '"</span>', false )
+				__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'twentyseventeen' ),
+				get_the_title()
 			) );
 
 			wp_link_pages( array(

--- a/components/post/content-video.php
+++ b/components/post/content-video.php
@@ -67,10 +67,10 @@
 
 		if ( is_single() || empty( $video ) ) :
 
+			/* translators: %s: Name of current post */
 			the_content( sprintf(
-				/* translators: %s: Name of current post */
-				__( 'Continue reading %s', 'twentyseventeen' ),
-				the_title( '<span class="screen-reader-text">"', '"</span>', false )
+				__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'twentyseventeen' ),
+				get_the_title()
 			) );
 
 			wp_link_pages( array(

--- a/components/post/content.php
+++ b/components/post/content.php
@@ -48,10 +48,10 @@
 
 	<div class="entry-content">
 		<?php
+			/* translators: %s: Name of current post */
 			the_content( sprintf(
-				/* translators: %s: Name of current post */
-				__( 'Continue reading %s', 'twentyseventeen' ),
-				the_title( '<span class="screen-reader-text">"', '"</span>', false )
+				__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'twentyseventeen' ),
+				get_the_title()
 			) );
 
 			wp_link_pages( array(

--- a/functions.php
+++ b/functions.php
@@ -189,12 +189,24 @@ function twentyseventeen_widgets_init() {
 add_action( 'widgets_init', 'twentyseventeen_widgets_init' );
 
 /**
- * Replaces the excerpt "more" text by a link.
+ * Replaces "[...]" (appended to automatically generated excerpts) with ... and
+ * a 'Continue reading' link.
+ *
+ * Create your own twentysixteen_excerpt_more() function to override in a child theme.
+ *
+ * @since Twenty Seventeen 1.0
+ *
+ * @return string 'Continue reading' link prepended with an ellipsis.
  */
-function twentyseventeen_excerpt_continue_reading() {
-	return ' &hellip; <p class="link-more"><a href="' . esc_url( get_permalink() ) . '">' . sprintf( __( 'Continue reading %s', 'twentyseventeen' ), the_title( '<span class="screen-reader-text">"', '"</span>', false ) ) . '</a></p>';
+function twentyseventeen_excerpt_more() {
+	$link = sprintf( '<p class="link-more"><a href="%1$s" class="more-link">%2$s</a></p>',
+		esc_url( get_permalink( get_the_ID() ) ),
+		/* translators: %s: Name of current post */
+		sprintf( __( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'twentyseventeen' ), get_the_title( get_the_ID() ) )
+	);
+	return ' &hellip; ' . $link;
 }
-add_filter( 'excerpt_more', 'twentyseventeen_excerpt_continue_reading' );
+add_filter( 'excerpt_more', 'twentyseventeen_excerpt_more' );
 
 /**
  * Handles JavaScript detection.


### PR DESCRIPTION
- This makes it easier to translate and understand context for translators.
- Follows pattern in Twenty Sixteen.

Fixes #420.
