### PR TITLE
Updating header styles for custom header on all pages

### DIFF
--- a/assets/css/editor-style.css
+++ b/assets/css/editor-style.css
@@ -269,10 +269,14 @@ table {
 }
 
 a {
+	-webkit-box-shadow: inset 0 -1px 0 rgba(15, 15, 15, 1);
 	box-shadow: inset 0 -1px 0 rgba(15, 15, 15, 1);
 	color: #222;
 	text-decoration: none;
+	-webkit-transition: color 80ms ease-in, -webkit-box-shadow 130ms ease-in-out;
+	transition: color 80ms ease-in, -webkit-box-shadow 130ms ease-in-out;
 	transition: color 80ms ease-in, box-shadow 130ms ease-in-out;
+	transition: color 80ms ease-in, box-shadow 130ms ease-in-out, -webkit-box-shadow 130ms ease-in-out;
 }
 
 a:focus {
@@ -282,6 +286,7 @@ a:focus {
 a:hover,
 a:focus {
 	color: #000;
+	-webkit-box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 3px 0 rgba(0, 0, 0, 1);
 	box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 3px 0 rgba(0, 0, 0, 1);
 }
 
@@ -289,6 +294,7 @@ a:focus {
 
 a img {
 	background: #fff;
+	-webkit-box-shadow: 0 0 0 6px #fff;
 	box-shadow: 0 0 0 6px #fff;
 }
 
@@ -350,6 +356,7 @@ object {
 .gallery-item a,
 .gallery-item a:hover,
 .gallery-item a:focus {
+	-webkit-box-shadow: none;
 	box-shadow: none;
 	background: none;
 	display: inline-block;
@@ -527,6 +534,7 @@ object {
 .wp-playlist-item a,
 .wp-playlist-item a:focus,
 .wp-playlist-item a:hover {
+	-webkit-box-shadow: none;
 	box-shadow: none;
 	background: transparent;
 }

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -14,6 +14,7 @@
 			$sidebar = $body.find( '#secondary' ),
 			$entryContent = $body.find( '.entry-content' ),
 			$formatQuote = $body.find( '.format-quote blockquote' ),
+			isFrontPage = $body.hasClass( 'twentyseventeen-front-page' ) || $body.hasClass( 'home blog' ),
 			navigationFixedClass = 'site-navigation-fixed',
 			navigationHeight,
 			navigationOuterHeight,
@@ -49,7 +50,7 @@
 			if ( navIsNotTooTall ) {
 
 				// When there's a custom header image, the header offset includes the height of the navigation
-				if ( $customHeaderImage.length ) {
+				if ( isFrontPage && $customHeaderImage.length ) {
 					headerOffset = $customHeader.innerHeight() - navigationOuterHeight;
 				} else {
 					headerOffset = $customHeader.innerHeight();
@@ -75,9 +76,14 @@
 	 */
 	function adjustHeaderHeight() {
 		if ( 'none' === $menuToggle.css( 'display' ) ) {
-			$branding.css( 'margin-bottom', navigationOuterHeight );
+			// The margin should be applied to different elements on front-page or home vs interior pages.
+			if ( isFrontPage ) {
+				$branding.css( 'margin-bottom', navigationOuterHeight );
+			} else {
+				$customHeader.css( 'margin-bottom', navigationOuterHeight );
+			}
 		} else {
-			$branding.css( 'margin-bottom', '0' );
+			$customHeader.css( 'margin-bottom', '0' );
 		}
 	}
 

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -86,6 +86,7 @@
 
 		} else {
 			$customHeader.css( 'margin-bottom', '0' );
+			$branding.css( 'margin-bottom', '0' );
 		}
 	}
 

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -76,12 +76,14 @@
 	 */
 	function adjustHeaderHeight() {
 		if ( 'none' === $menuToggle.css( 'display' ) ) {
+
 			// The margin should be applied to different elements on front-page or home vs interior pages.
 			if ( isFrontPage ) {
 				$branding.css( 'margin-bottom', navigationOuterHeight );
 			} else {
 				$customHeader.css( 'margin-bottom', navigationOuterHeight );
 			}
+
 		} else {
 			$customHeader.css( 'margin-bottom', '0' );
 		}

--- a/components/header/header-image.php
+++ b/components/header/header-image.php
@@ -11,38 +11,29 @@
 ?>
 <div class="custom-header">
 	<?php
+	$header_image = get_header_image();
 
-		// If front page.
-		if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) :
+	// Check if Custom Header image has been added.
+	if ( ! empty( $header_image ) ) : ?>
 
-			// Check if Custom Header image has been added.
-			$header_image = get_header_image();
-			if ( ! empty( $header_image ) ) : ?>
+		<div class="custom-header-image" style="background-image: url(<?php echo esc_url( $header_image ); ?>)"></div>
+		<?php get_template_part( 'components/header/site', 'branding' ); ?>
 
-				<div class="custom-header-image" style="background-image: url(<?php echo esc_url( $header_image ); ?>)"></div>
-				<?php get_template_part( 'components/header/site', 'branding' ); ?>
+	<?php elseif ( twentyseventeen_is_frontpage() && has_post_thumbnail() ) :
+		// If not, fall back to front page's featured image, only on the front page.
+		$post_thumbnail_id = get_post_thumbnail_id( $post->ID );
+		$thumbnail_attributes = wp_get_attachment_image_src( $post_thumbnail_id, 'twentyseventeen-featured-image' );
+		?>
 
-			<?php elseif ( twentyseventeen_is_frontpage() && has_post_thumbnail() ) :
-				// If not, fall back to front page's featured image.
-				$post_thumbnail_id = get_post_thumbnail_id( $post->ID );
-				$thumbnail_attributes = wp_get_attachment_image_src( $post_thumbnail_id, 'twentyseventeen-featured-image' );
-				?>
+		<div class="custom-header-image" style="background-image: url(<?php echo esc_url( $thumbnail_attributes[0] ); ?>)"></div>
+		<?php get_template_part( 'components/header/site', 'branding' ); ?>
 
-				<div class="custom-header-image" style="background-image: url(<?php echo esc_url( $thumbnail_attributes[0] ); ?>)"></div>
-				<?php get_template_part( 'components/header/site', 'branding' ); ?>
+	<?php else : ?>
+		<?php // Otherwise, show a blank header. ?>
+		<div class="custom-header-simple">
+			<?php get_template_part( 'components/header/site', 'branding' ); ?>
+		</div><!-- .custom-header-simple -->
 
-			<?php else : ?>
-				<?php // Otherwise, show a blank header. ?>
-				<div class="custom-header-simple">
-					<?php get_template_part( 'components/header/site', 'branding' ); ?>
-				</div><!-- .custom-header-simple -->
-
-			<?php endif;
-		// If not the front page, show a shorter plain header.
-		else : ?>
-			<div class="custom-header-simple">
-				<?php get_template_part( 'components/header/site', 'branding' ); ?>
-			</div><!-- .custom-header-simple -->
 	<?php endif; ?>
 
 </div><!-- .custom-header -->

--- a/components/post/content-audio.php
+++ b/components/post/content-audio.php
@@ -26,6 +26,7 @@
 						twentyseventeen_posted_on();
 					else :
 						echo twentyseventeen_time_link();
+						twentyseventeen_edit_link();
 					endif;
 				echo '</div><!-- .entry-meta -->';
 			endif;

--- a/components/post/content-excerpt.php
+++ b/components/post/content-excerpt.php
@@ -19,7 +19,14 @@
 	<header class="entry-header">
 		<?php if ( 'post' === get_post_type() ) : ?>
 			<div class="entry-meta">
-				<?php echo twentyseventeen_time_link(); ?>
+				<?php
+					echo twentyseventeen_time_link();
+					twentyseventeen_edit_link();
+				?>
+			</div><!-- .entry-meta -->
+		<?php elseif ( 'page' === get_post_type() && get_edit_post_link() ) : ?>
+			<div class="entry-meta">
+				<?php twentyseventeen_edit_link(); ?>
 			</div><!-- .entry-meta -->
 		<?php endif; ?>
 

--- a/components/post/content-gallery.php
+++ b/components/post/content-gallery.php
@@ -25,6 +25,7 @@
 						twentyseventeen_posted_on();
 					else :
 						echo twentyseventeen_time_link();
+						twentyseventeen_edit_link();
 					endif;
 				echo '</div><!-- .entry-meta -->';
 			endif;

--- a/components/post/content-image.php
+++ b/components/post/content-image.php
@@ -25,6 +25,7 @@
 						twentyseventeen_posted_on();
 					else :
 						echo twentyseventeen_time_link();
+						twentyseventeen_edit_link();
 					endif;
 				echo '</div><!-- .entry-meta -->';
 			endif;

--- a/components/post/content-video.php
+++ b/components/post/content-video.php
@@ -25,6 +25,7 @@
 						twentyseventeen_posted_on();
 					else :
 						echo twentyseventeen_time_link();
+						twentyseventeen_edit_link();
 					endif;
 				echo '</div><!-- .entry-meta -->';
 			endif;

--- a/components/post/content.php
+++ b/components/post/content.php
@@ -26,6 +26,7 @@
 						twentyseventeen_posted_on();
 					else :
 						echo twentyseventeen_time_link();
+						twentyseventeen_edit_link();
 					endif;
 				echo '</div><!-- .entry-meta -->';
 			endif;

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -17,7 +17,7 @@
 function twentyseventeen_custom_header_setup() {
 	add_theme_support( 'custom-header', apply_filters( 'twentyseventeen_custom_header_args', array(
 		'default-image'      => get_parent_theme_file_uri( '/assets/images/header.jpg' ),
-		'default-text-color' => '222222',
+		'default-text-color' => 'ffffff',
 		'width'              => 2000,
 		'height'             => 1200,
 		'flex-height'        => true,

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -34,11 +34,6 @@ function twentyseventeen_body_classes( $classes ) {
 		$classes[] = 'twentyseventeen-front-page';
 	}
 
-	// Add class if no custom header or featured images.
-	if ( ! has_header_image() && ( ! has_post_thumbnail() || is_home() ) ) {
-		$classes[] = 'no-header-image';
-	}
-
 	// Add a class if there is a featured image or custom header.
 	if ( has_header_image() || ( has_post_thumbnail() && twentyseventeen_is_frontpage() ) ) {
 		$classes[] = 'has-header-image';

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -39,6 +39,11 @@ function twentyseventeen_body_classes( $classes ) {
 		$classes[] = 'no-header-image';
 	}
 
+	// Add a class if there is a featured image or custom header.
+	if ( has_header_image() || ( has_post_thumbnail() && twentyseventeen_is_frontpage() ) ) {
+		$classes[] = 'has-header-image';
+	}
+
 	// Add class if sidebar is used.
 	if ( is_active_sidebar( 'sidebar-1' ) && ! is_page() ) {
 		$classes[] = 'has-sidebar';

--- a/index.php
+++ b/index.php
@@ -18,16 +18,10 @@
 get_header(); ?>
 
 <div class="wrap">
-	<?php
-	if ( is_home() && ! is_front_page() ) : ?>
-		<header class="page-header">
-			<h1 class="page-title"><?php single_post_title(); ?></h1>
-		</header>
-	<?php elseif ( is_home() ) : ?>
-		<header class="page-header">
-			<h2 class="page-title"><?php echo get_the_title( get_option( 'page_for_posts' ) ); ?></h2>
-		</header>
-	<?php endif; ?>
+	<header class="page-header">
+		<h2 class="page-title"><?php _e( 'Posts', 'twentyseventeen' ); ?></h2>
+	</header>
+
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main" role="main">
 

--- a/index.php
+++ b/index.php
@@ -18,9 +18,15 @@
 get_header(); ?>
 
 <div class="wrap">
+	<?php if ( is_home() && ! is_front_page() ) : ?>
+		<header class="page-header">
+			<h1 class="page-title"><?php single_post_title(); ?></h1>
+		</header>
+	<?php else : ?>
 	<header class="page-header">
 		<h2 class="page-title"><?php _e( 'Posts', 'twentyseventeen' ); ?></h2>
 	</header>
+	<?php endif; ?>
 
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main" role="main">

--- a/rtl.css
+++ b/rtl.css
@@ -91,7 +91,6 @@ input[type="checkbox"] {
 }
 
 /* Blog, Archive, Search */
-
 .blog .entry-meta a.post-edit-link,
 .archive .entry-meta a.post-edit-link,
 .search .entry-meta a.post-edit-link {

--- a/rtl.css
+++ b/rtl.css
@@ -140,9 +140,7 @@ input[type="checkbox"] {
 	left: auto;
 	right: -2em;
 	-webkit-transform: scale(-1, 1);
-	-moz-transform: scale(-1, 1);
 	-ms-transform: scale(-1, 1);
-	-o-transform: scale(-1, 1);
 	transform: scale(-1, 1);
 }
 
@@ -183,9 +181,7 @@ input[type="checkbox"] {
 	left: auto;
 	right: -1.25em;
 	-webkit-transform: none;
-	-moz-transform: none;
 	-ms-transform: none;
-	-o-transform: none;
 	transform: none;
 }
 

--- a/rtl.css
+++ b/rtl.css
@@ -91,6 +91,7 @@ input[type="checkbox"] {
 }
 
 /* Blog, Archive, Search */
+
 .blog .entry-meta a.post-edit-link,
 .archive .entry-meta a.post-edit-link,
 .search .entry-meta a.post-edit-link {

--- a/rtl.css
+++ b/rtl.css
@@ -92,6 +92,12 @@ input[type="checkbox"] {
 
 /* Blog, Archive, Search */
 
+.blog .entry-meta a.post-edit-link,
+.archive .entry-meta a.post-edit-link {
+	margin-left: 0;
+	margin-right: 1.0em;
+}
+
 .sticky .icon-pinned {
 	left: auto;
 	right: -1em;

--- a/rtl.css
+++ b/rtl.css
@@ -178,8 +178,7 @@ input[type="checkbox"] {
 
 /* Post Formats */
 
-.format-quote blockquote:before {
-	content: "\f106";
+.format-quote blockquote .icon {
 	left: auto;
 	right: -1.25em;
 	-webkit-transform: none;
@@ -419,7 +418,7 @@ input[type="checkbox"] {
 
 	/* Post formats */
 
-	.format-quote blockquote:before {
+	.format-quote blockquote .icon {
 		left: auto;
 		right: -1.5em;
 	}

--- a/rtl.css
+++ b/rtl.css
@@ -93,9 +93,14 @@ input[type="checkbox"] {
 /* Blog, Archive, Search */
 
 .blog .entry-meta a.post-edit-link,
-.archive .entry-meta a.post-edit-link {
+.archive .entry-meta a.post-edit-link,
+.search .entry-meta a.post-edit-link {
 	margin-left: 0;
 	margin-right: 1.0em;
+}
+
+.search .page .entry-meta a.post-edit-link {
+	margin-right: 0;
 }
 
 .sticky .icon-pinned {

--- a/style.css
+++ b/style.css
@@ -1813,10 +1813,15 @@ body:not(.twentyseventeen-front-page) .entry-header {
 }
 
 .blog .entry-meta a.post-edit-link,
-.archive .entry-meta a.post-edit-link {
+.archive .entry-meta a.post-edit-link,
+.search .entry-meta a.post-edit-link {
 	color: #222;
 	display: inline-block;
 	margin-left: 1.0em;
+}
+
+.search .page .entry-meta a.post-edit-link {
+	margin-left: 0;
 }
 
 .taxonomy-description {
@@ -2021,6 +2026,11 @@ body:not(.twentyseventeen-front-page) .entry-header {
 .page .entry-header .edit-link {
 	font-size: 14px;
 	font-size: 0.875rem;
+}
+
+.search .page .entry-header .edit-link {
+	font-size: 11px;
+	font-size: 0.6875rem;
 }
 
 .page-links {

--- a/style.css
+++ b/style.css
@@ -14,7 +14,6 @@ This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 */
 
-
 /*--------------------------------------------------------------
 >>> TABLE OF CONTENTS:
 ----------------------------------------------------------------

--- a/style.css
+++ b/style.css
@@ -1562,6 +1562,26 @@ body:not(.title-tagline-hidden) .site-branding-text {
 	background-position: center center;
 	background-repeat: no-repeat;
 	background-size: cover;
+	height: 165px;
+}
+
+.custom-header-image:before {
+	/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#000000+0,000000+100&0+0,0.3+75 */
+	background: -moz-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* FF3.6-15 */
+	background: -webkit-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* Chrome10-25,Safari5.1-6 */
+	background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#00000000", endColorstr="#4d000000", GradientType=0); /* IE6-9 */
+	bottom: 0;
+	content: "";
+	display: block;
+	height: 100%;
+	left: 0;
+	position: absolute;
+	right: 0;
+}
+
+.twentyseventeen-front-page.has-header-image .custom-header-image,
+.home.blog.has-header-image .custom-header-image {
 	height: 0;
 	padding-top: 66%;
 }
@@ -3144,24 +3164,8 @@ article.panel-placeholder {
 
 	.custom-header-image {
 		height: 165px;
-		padding: 10% 0;
 		position: relative;
 		background-position: bottom;
-	}
-
-	.custom-header-image:before {
-		/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#000000+0,000000+100&0+0,0.3+75 */
-		background: -moz-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* FF3.6-15 */
-		background: -webkit-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* Chrome10-25,Safari5.1-6 */
-		background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
-		filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#00000000", endColorstr="#4d000000", GradientType=0); /* IE6-9 */
-		bottom: 0;
-		content: "";
-		display: block;
-		height: 100%;
-		left: 0;
-		position: absolute;
-		right: 0;
 	}
 
 	.no-header-image .custom-header-image {
@@ -3439,6 +3443,7 @@ article.panel-placeholder {
 		height: 1200px;
 		height: 100vh;
 		max-height: 100%;
+		padding: 10% 0;
 	}
 
 	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image:before,

--- a/style.css
+++ b/style.css
@@ -14,6 +14,7 @@ This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 */
 
+
 /*--------------------------------------------------------------
 >>> TABLE OF CONTENTS:
 ----------------------------------------------------------------

--- a/style.css
+++ b/style.css
@@ -85,6 +85,8 @@ figure {
 }
 
 hr {
+	-webkit-box-sizing: content-box;
+	-moz-box-sizing: content-box;
 	box-sizing: content-box;
 	height: 0;
 	overflow: visible;
@@ -224,6 +226,8 @@ fieldset {
 }
 
 legend {
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 	color: inherit;
 	display: table;
@@ -243,6 +247,8 @@ textarea {
 
 [type="checkbox"],
 [type="radio"] {
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 	padding: 0;
 }
@@ -304,7 +310,9 @@ template {
 
 .screen-reader-text:focus {
 	background-color: #f1f1f1;
+	-webkit-border-radius: 3px;
 	border-radius: 3px;
+	-webkit-box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
 	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
 	clip: auto !important;
 	color: #21759b;
@@ -918,6 +926,7 @@ input[type="color"],
 textarea {
 	color: #666;
 	border: 1px solid #bbb;
+	-webkit-border-radius: 3px;
 	border-radius: 3px;
 	display: block;
 	padding: 0.7em;
@@ -946,6 +955,7 @@ textarea:focus {
 
 select {
 	border: 1px solid #bbb;
+	-webkit-border-radius: 3px;
 	border-radius: 3px;
 	height: 3em;
 	max-width: 100%;
@@ -966,7 +976,9 @@ input[type="button"],
 input[type="submit"] {
 	background-color: #222;
 	border: 0;
+	-webkit-border-radius: 2px;
 	border-radius: 2px;
+	-webkit-box-shadow: none;
 	box-shadow: none;
 	color: #fff;
 	cursor: pointer;
@@ -1129,8 +1141,12 @@ a:active {
 .site-footer .widget-area a,
 .posts-navigation a,
 .widget_authors a strong {
+	-webkit-box-shadow: inset 0 -1px 0 rgba(15, 15, 15, 1);
 	box-shadow: inset 0 -1px 0 rgba(15, 15, 15, 1);
+	-webkit-transition: color 80ms ease-in, -webkit-box-shadow 130ms ease-in-out;
+	transition: color 80ms ease-in, -webkit-box-shadow 130ms ease-in-out;
 	transition: color 80ms ease-in, box-shadow 130ms ease-in-out;
+	transition: color 80ms ease-in, box-shadow 130ms ease-in-out, -webkit-box-shadow 130ms ease-in-out;
 }
 
 .entry-title a,
@@ -1154,9 +1170,13 @@ a .nav-title,
 .widget ul li a,
 .site-footer .widget-area ul li a,
 .site-footer .widget-area ul li a {
+	-webkit-box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 1);
 	box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 1);
 	text-decoration: none;
+	-webkit-transition: color 80ms ease-in, -webkit-box-shadow 130ms ease-in-out;
+	transition: color 80ms ease-in, -webkit-box-shadow 130ms ease-in-out;
 	transition: color 80ms ease-in, box-shadow 130ms ease-in-out;
+	transition: color 80ms ease-in, box-shadow 130ms ease-in-out, -webkit-box-shadow 130ms ease-in-out;
 }
 
 .entry-content a:focus,
@@ -1180,6 +1200,7 @@ a .nav-title,
 .project-terms a:focus,
 .project-terms a:hover {
 	color: #000;
+	-webkit-box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 3px 0 rgba(0, 0, 0, 1);
 	box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 3px 0 rgba(0, 0, 0, 1);
 }
 
@@ -1210,12 +1231,14 @@ a:hover .nav-title,
 .widget ul li a:focus,
 .widget ul li a:hover {
 	color: #000;
+	-webkit-box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 3px 0 rgba(0, 0, 0, 1);
 	box-shadow: inset 0 0 0 rgba(0, 0, 0, 0), 0 3px 0 rgba(0, 0, 0, 1);
 }
 
 /* Fixes linked images */
 .entry-content a img,
 .widget a img {
+	-webkit-box-shadow: 0 0 0 8px #fff;
 	box-shadow: 0 0 0 8px #fff;
 }
 
@@ -1345,6 +1368,7 @@ a:hover .nav-title,
 .menu-toggle {
 	background-color: transparent;
 	border: 0;
+	-webkit-box-shadow: none;
 	box-shadow: none;
 	color: #222;
 	display: none;
@@ -1370,6 +1394,7 @@ a:hover .nav-title,
 .menu-toggle:hover,
 .menu-toggle:focus {
 	background-color: transparent;
+	-webkit-box-shadow: none;
 	box-shadow: none;
 }
 
@@ -1396,6 +1421,7 @@ a:hover .nav-title,
 .dropdown-toggle {
 	background-color: transparent;
 	border: 0;
+	-webkit-box-shadow: none;
 	box-shadow: none;
 	color: #222;
 	display: block;
@@ -1435,6 +1461,8 @@ a:hover .nav-title,
 --------------------------------------------------------------*/
 
 html {
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
 
@@ -1442,6 +1470,8 @@ html {
 *:before,
 *:after {
 	/* Inherit box-sizing to make it easier to change the property for components that leverage other behavior; see http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
+	-webkit-box-sizing: inherit;
+	-moz-box-sizing: inherit;
 	box-sizing: inherit;
 }
 
@@ -1581,6 +1611,7 @@ body:not(.title-tagline-hidden) .site-branding-text {
 .custom-header-image {
 	background-position: center center;
 	background-repeat: no-repeat;
+	-webkit-background-size: cover;
 	background-size: cover;
 	height: 0;
 	padding-top: 66%;
@@ -1606,14 +1637,16 @@ body:not(.title-tagline-hidden) .site-branding-text {
 .panel-image {
 	background-position: center center;
 	background-repeat: no-repeat;
+	-webkit-background-size: cover;
 	background-size: cover;
 	position: relative;
 }
 
 .panel-image:before {
-	/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#000000+0,000000+100&0+0,0.3+100 */
-	background: -moz-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 100%); /* FF3.6-15 */
+	/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#000000+0,000000+100&0+0,0.3+100 */ /* FF3.6-15 */
 	background: -webkit-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 100%); /* Chrome10-25,Safari5.1-6 */
+	background: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0)), to(rgba(0, 0, 0, 0.3)));
+	background: -webkit-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 100%);
 	background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#00000000", endColorstr="#4d000000", GradientType=0); /* IE6-9 */
 	bottom: 0;
@@ -1777,6 +1810,7 @@ body.page:not(.twentyseventeen-front-page) .entry-title {
 .prev.page-numbers,
 .next.page-numbers {
 	background-color: #ddd;
+	-webkit-border-radius: 2px;
 	border-radius: 2px;
 	font-size: 24px;
 	font-size: 1.5rem;
@@ -1939,7 +1973,9 @@ body:not(.twentyseventeen-front-page) .entry-header {
 
 .entry-footer .edit-link a.post-edit-link {
 	background-color: #222;
+	-webkit-border-radius: 2px;
 	border-radius: 2px;
+	-webkit-box-shadow: none;
 	box-shadow: none;
 	color: #fff;
 	display: inline-block;
@@ -1982,9 +2018,7 @@ body:not(.twentyseventeen-front-page) .entry-header {
 	position: absolute;
 	top: 0.4em;
 	-webkit-transform: scale(-1, 1);
-	-moz-transform: scale(-1, 1);
 	-ms-transform: scale(-1, 1);
-	-o-transform: scale(-1, 1);
 	transform: scale(-1, 1);
 	width: 20px;
 }
@@ -2100,6 +2134,7 @@ body:not(.twentyseventeen-front-page) .entry-header {
 
 .social-navigation a {
 	background-color: #767676;
+	-webkit-border-radius: 40px;
 	border-radius: 40px;
 	color: #fff;
 	display: inline-block;
@@ -2240,6 +2275,7 @@ body:not(.twentyseventeen-front-page) .entry-header {
 
 .bypostauthor > .comment-body > .comment-meta > .comment-author:before {
 	background: #222;
+	-webkit-border-radius: 20px;
 	border-radius: 20px;
 	border: 1px solid #fff;
 	color: #fff;
@@ -2494,6 +2530,7 @@ h2.widget-title {
 .widget.widget_tag_cloud a,
 .wp_widget_tag_cloud a {
 	border: 1px solid #ddd;
+	-webkit-box-shadow: none;
 	box-shadow: none;
 	display: inline-block;
 	float: left;
@@ -2517,6 +2554,7 @@ h2.widget-title {
 .wp_widget_tag_cloud a:hover,
 .wp_widget_tag_cloud a:focus {
 	border-color: #bbb;
+	-webkit-box-shadow: none;
 	box-shadow: none;
 	text-decoration: none;
 }
@@ -2719,6 +2757,7 @@ object {
 .site-content .wp-playlist-item a,
 .site-content .wp-playlist-item a:focus,
 .site-content .wp-playlist-item a:hover {
+	-webkit-box-shadow: none;
 	box-shadow: none;
 	background: transparent;
 }
@@ -2763,6 +2802,7 @@ object {
 .gallery-item a,
 .gallery-item a:hover,
 .gallery-item a:focus {
+	-webkit-box-shadow: none;
 	box-shadow: none;
 	background: none;
 	display: inline-block;
@@ -2770,13 +2810,17 @@ object {
 
 .gallery-item a img {
 	display: block;
+	-webkit-transition: -webkit-filter 0.2s ease-in;
+	transition: -webkit-filter 0.2s ease-in;
 	transition: filter 0.2s ease-in;
+	transition: filter 0.2s ease-in, -webkit-filter 0.2s ease-in;
 	-webkit-backface-visibility: hidden;
 	backface-visibility: hidden;
 }
 
 .gallery-item a:hover img,
 .gallery-item a:focus img {
+	-webkit-filter: opacity(60%);
 	filter: opacity(60%);
 }
 
@@ -2824,6 +2868,8 @@ object {
 	right: 3.2em;
 	text-transform: uppercase;
 	top: 3.2em;
+	-webkit-transform: translate(3px, -3px);
+	-ms-transform: translate(3px, -3px);
 	transform: translate(3px, -3px);
 	z-index: 3;
 }
@@ -3170,9 +3216,10 @@ article.panel-placeholder {
 	}
 
 	.custom-header-image:before {
-		/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#000000+0,000000+100&0+0,0.3+75 */
-		background: -moz-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* FF3.6-15 */
+		/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#000000+0,000000+100&0+0,0.3+75 */ /* FF3.6-15 */
 		background: -webkit-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* Chrome10-25,Safari5.1-6 */
+		background: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0)), color-stop(75%, rgba(0, 0, 0, 0.3)), to(rgba(0, 0, 0, 0.3)));
+		background: -webkit-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%);
 		background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
 		filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#00000000", endColorstr="#4d000000", GradientType=0); /* IE6-9 */
 		bottom: 0;
@@ -3458,6 +3505,7 @@ article.panel-placeholder {
 
 	.admin-bar.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
 	.admin-bar.home.blog:not(.no-header-image) .custom-header-image {
+		height: -webkit-calc(100vh - 32px);
 		height: calc(100vh - 32px);
 	}
 

--- a/style.css
+++ b/style.css
@@ -1812,6 +1812,13 @@ body:not(.twentyseventeen-front-page) .entry-header {
 	padding-top: 0;
 }
 
+.blog .entry-meta a.post-edit-link,
+.archive .entry-meta a.post-edit-link {
+	color: #222;
+	display: inline-block;
+	margin-left: 1.0em;
+}
+
 .taxonomy-description {
 	color: #666;
 	font-size: 13px;

--- a/style.css
+++ b/style.css
@@ -1475,8 +1475,7 @@ body {
 	transition: margin-bottom 0.2s;
 }
 
-.twentyseventeen-front-page:not(.no-header-image) .site-branding,
-.home.blog:not(.no-header-image) .site-branding {
+body.has-header-image .site-branding {
 	bottom: 0;
 	position: absolute;
 	width: 100%;
@@ -1510,10 +1509,8 @@ body {
 	color: #222;
 }
 
-.twentyseventeen-front-page:not(.no-header-image) .site-title,
-.twentyseventeen-front-page:not(.no-header-image) .site-title a,
-.home.blog:not(.no-header-image) .site-title,
-.home.blog:not(.no-header-image) .site-title a {
+body.has-header-image .site-title,
+body.has-header-image .site-title a {
 	color: #fff;
 }
 
@@ -1524,8 +1521,7 @@ body {
 	margin-bottom: 0;
 }
 
-.twentyseventeen-front-page:not(.no-header-image) .site-description,
-.home.blog:not(.no-header-image) .site-description {
+body.has-header-image .site-description {
 	color: #fff;
 	opacity: 0.8;
 }
@@ -3143,14 +3139,14 @@ article.panel-placeholder {
 	/* Site Branding */
 
 	.site-branding {
-		margin-bottom: 70px;
+		margin-bottom: 0;
 	}
 
 	.custom-header-image {
-		height: 750px;
-		height: 75vh;
+		height: 165px;
 		padding: 10% 0;
 		position: relative;
+		background-position: bottom;
 	}
 
 	.custom-header-image:before {
@@ -3162,7 +3158,7 @@ article.panel-placeholder {
 		bottom: 0;
 		content: "";
 		display: block;
-		height: 33%;
+		height: 100%;
 		left: 0;
 		position: absolute;
 		right: 0;
@@ -3433,11 +3429,21 @@ article.panel-placeholder {
 
 	/* Front Page */
 
+	.twentyseventeen-front-page:not(.no-header-image) .site-branding,
+	.home.blog:not(.no-header-image) .site-branding {
+		margin-bottom: 70px;
+	}
+
 	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
 	.home.blog:not(.no-header-image) .custom-header-image {
 		height: 1200px;
 		height: 100vh;
 		max-height: 100%;
+	}
+
+	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image:before,
+	.home.blog:not(.no-header-image) .custom-header-image:before {
+		height: 33%;
 	}
 
 	.admin-bar.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
@@ -3775,10 +3781,6 @@ article.panel-placeholder {
 }
 
 @media screen and ( min-width: 55em ) {
-
-	.custom-header-image {
-		background-attachment: fixed;
-	}
 
 	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
 	.home.blog:not(.no-header-image) .custom-header-image {

--- a/style.css
+++ b/style.css
@@ -1590,6 +1590,10 @@ body:not(.title-tagline-hidden) .site-branding-text {
 	right: 0;
 }
 
+.has-header-image:not(.twentyseventeen-front-page):not(.home) .custom-header-image {
+	background-position: center bottom;
+}
+
 body:not(.has-header-image) .custom-header-image {
 	padding: 5% 0;
 }
@@ -3183,11 +3187,9 @@ article.panel-placeholder {
 	.custom-header-image {
 		height: 165px;
 		position: relative;
-		background-position: bottom;
 	}
 
 	.has-header-image:not(.twentyseventeen-front-page):not(.home) .custom-header-image {
-		background-position: center center;
 		bottom: 0;
 		height: auto;
 		left: 0;

--- a/style.css
+++ b/style.css
@@ -3187,6 +3187,7 @@ article.panel-placeholder {
 	}
 
 	.has-header-image:not(.twentyseventeen-front-page):not(.home) .custom-header-image {
+		background-position: center center;
 		bottom: 0;
 		height: auto;
 		left: 0;

--- a/style.css
+++ b/style.css
@@ -3266,6 +3266,7 @@ article.panel-placeholder {
 	}
 
 	.has-header-image:not(.twentyseventeen-front-page):not(.home) .custom-header-image {
+		background-position: center center;
 		bottom: 0;
 		height: auto;
 		left: 0;

--- a/style.css
+++ b/style.css
@@ -1560,6 +1560,7 @@ body:not(.title-tagline-hidden) .site-branding-text {
 .has-header-image.twentyseventeen-front-page .custom-header,
 .has-header-image.home.blog .custom-header {
 	display: flex;
+	min-height: 300px;
 	min-height: 75vh;
 }
 

--- a/style.css
+++ b/style.css
@@ -1637,6 +1637,10 @@ body:not(.title-tagline-hidden) .site-branding-text {
 	right: 0;
 }
 
+.has-header-image:not(.twentyseventeen-front-page):not(.home) .custom-header-image {
+	background-position: center bottom;
+}
+
 body:not(.has-header-image) .custom-header-image {
 	padding: 5% 0;
 }
@@ -3262,11 +3266,9 @@ article.panel-placeholder {
 	.custom-header-image {
 		height: 165px;
 		position: relative;
-		background-position: bottom;
 	}
 
 	.has-header-image:not(.twentyseventeen-front-page):not(.home) .custom-header-image {
-		background-position: center center;
 		bottom: 0;
 		height: auto;
 		left: 0;

--- a/style.css
+++ b/style.css
@@ -1606,6 +1606,7 @@ body:not(.title-tagline-hidden) .site-branding-text {
 .has-header-image.twentyseventeen-front-page .custom-header,
 .has-header-image.home.blog .custom-header {
 	display: flex;
+	min-height: 300px;
 	min-height: 75vh;
 }
 

--- a/style.css
+++ b/style.css
@@ -1609,6 +1609,26 @@ body:not(.title-tagline-hidden) .site-branding-text {
 	background-repeat: no-repeat;
 	-webkit-background-size: cover;
 	background-size: cover;
+	height: 165px;
+}
+
+.custom-header-image:before {
+	/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#000000+0,000000+100&0+0,0.3+75 */
+	background: -moz-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* FF3.6-15 */
+	background: -webkit-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* Chrome10-25,Safari5.1-6 */
+	background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#00000000", endColorstr="#4d000000", GradientType=0); /* IE6-9 */
+	bottom: 0;
+	content: "";
+	display: block;
+	height: 100%;
+	left: 0;
+	position: absolute;
+	right: 0;
+}
+
+.twentyseventeen-front-page.has-header-image .custom-header-image,
+.home.blog.has-header-image .custom-header-image {
 	height: 0;
 	padding-top: 66%;
 }
@@ -3223,25 +3243,8 @@ article.panel-placeholder {
 
 	.custom-header-image {
 		height: 165px;
-		padding: 10% 0;
 		position: relative;
 		background-position: bottom;
-	}
-
-	.custom-header-image:before {
-		/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#000000+0,000000+100&0+0,0.3+75 */ /* FF3.6-15 */
-		background: -webkit-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* Chrome10-25,Safari5.1-6 */
-		background: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0)), color-stop(75%, rgba(0, 0, 0, 0.3)), to(rgba(0, 0, 0, 0.3)));
-		background: -webkit-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%);
-		background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
-		filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#00000000", endColorstr="#4d000000", GradientType=0); /* IE6-9 */
-		bottom: 0;
-		content: "";
-		display: block;
-		height: 100%;
-		left: 0;
-		position: absolute;
-		right: 0;
 	}
 
 	.no-header-image .custom-header-image {
@@ -3519,6 +3522,7 @@ article.panel-placeholder {
 		height: 1200px;
 		height: 100vh;
 		max-height: 100%;
+		padding: 10% 0;
 	}
 
 	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image:before,

--- a/style.css
+++ b/style.css
@@ -1532,6 +1532,11 @@ body {
 	opacity: 0.7;
 }
 
+.has-header-image.twentyseventeen-front-page .site-branding,
+.has-header-image.home.blog .site-branding {
+	align-self: flex-end;
+}
+
 .site-title {
 	clear: none;
 	font-size: 24px;
@@ -1596,6 +1601,12 @@ body:not(.title-tagline-hidden) .site-branding-text {
 
 .custom-header {
 	position: relative;
+}
+
+.has-header-image.twentyseventeen-front-page .custom-header,
+.has-header-image.home.blog .custom-header {
+	display: flex;
+	min-height: 75vh;
 }
 
 .custom-header-image {
@@ -3236,8 +3247,15 @@ article.panel-placeholder {
 	.has-header-image.twentyseventeen-front-page .site-branding,
 	.has-header-image.home.blog .site-branding {
 		bottom: 0;
+		padding-top: 0;
 		position: absolute;
 		width: 100%;
+	}
+
+	.has-header-image.twentyseventeen-front-page .custom-header,
+	.has-header-image.home.blog .custom-header {
+		display: block;
+		min-height: 0;
 	}
 
 	.custom-header-image {

--- a/style.css
+++ b/style.css
@@ -1521,12 +1521,6 @@ body {
 	transition: margin-bottom 0.2s;
 }
 
-body.has-header-image .site-branding {
-	bottom: 0;
-	position: absolute;
-	width: 100%;
-}
-
 .site-branding a {
 	text-decoration: none;
 	-webkit-transition: opacity 0.2s;
@@ -1585,7 +1579,7 @@ body.has-header-image .site-description {
 	width: auto;
 }
 
-body.home.title-tagline-hidden:not(.no-header-image) .custom-logo-link img {
+body.home.title-tagline-hidden.has-header-image .custom-logo-link img {
 	max-height: 200px;
 	max-width: 100%;
 }
@@ -1609,7 +1603,11 @@ body:not(.title-tagline-hidden) .site-branding-text {
 	background-repeat: no-repeat;
 	-webkit-background-size: cover;
 	background-size: cover;
-	height: 165px;
+	bottom: 0;
+	left: 0;
+	position: absolute;
+	right: 0;
+	top: 0;
 }
 
 .custom-header-image:before {
@@ -1627,13 +1625,7 @@ body:not(.title-tagline-hidden) .site-branding-text {
 	right: 0;
 }
 
-.twentyseventeen-front-page.has-header-image .custom-header-image,
-.home.blog.has-header-image .custom-header-image {
-	height: 0;
-	padding-top: 66%;
-}
-
-.no-header-image .custom-header-image {
+body:not(.has-header-image) .custom-header-image {
 	padding: 5% 0;
 }
 
@@ -3241,14 +3233,33 @@ article.panel-placeholder {
 		margin-bottom: 0;
 	}
 
+	.has-header-image.twentyseventeen-front-page .site-branding,
+	.has-header-image.home.blog .site-branding {
+		bottom: 0;
+		position: absolute;
+		width: 100%;
+	}
+
 	.custom-header-image {
 		height: 165px;
 		position: relative;
 		background-position: bottom;
 	}
 
-	.no-header-image .custom-header-image {
-		min-height: 20vh;
+	.has-header-image:not(.twentyseventeen-front-page):not(.home) .custom-header-image {
+		bottom: 0;
+		height: auto;
+		left: 0;
+		position: absolute;
+		right: 0;
+		top: 0;
+	}
+
+	.twentyseventeen-front-page.has-header-image .custom-header-image,
+	.home.blog.has-header-image .custom-header-image {
+		height: 0;
+		padding-top: 66%;
+		position: relative;
 	}
 
 	.custom-logo-link {
@@ -3256,11 +3267,11 @@ article.panel-placeholder {
 	}
 
 	.custom-logo-link img,
-	body.home.title-tagline-hidden:not(.no-header-image) .custom-logo-link img {
+	body.home.title-tagline-hidden.has-header-image .custom-logo-link img {
 		max-width: 350px;
 	}
 
-	.title-tagline-hidden.home:not(.no-header-image) .custom-logo-link img {
+	.title-tagline-hidden.home.has-header-image .custom-logo-link img {
 		max-height: 200px;
 	}
 
@@ -3512,27 +3523,26 @@ article.panel-placeholder {
 
 	/* Front Page */
 
-	.twentyseventeen-front-page:not(.no-header-image) .site-branding,
-	.home.blog:not(.no-header-image) .site-branding {
+	.twentyseventeen-front-page.has-header-image .site-branding,
+	.home.blog.has-header-image .site-branding {
 		margin-bottom: 70px;
 	}
 
-	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
-	.home.blog:not(.no-header-image) .custom-header-image {
+	.twentyseventeen-front-page.has-header-image .custom-header-image,
+	.home.blog.has-header-image .custom-header-image {
 		height: 1200px;
 		height: 100vh;
 		max-height: 100%;
 		padding: 10% 0;
 	}
 
-	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image:before,
-	.home.blog:not(.no-header-image) .custom-header-image:before {
+	.twentyseventeen-front-page.has-header-image .custom-header-image:before,
+	.home.blog.has-header-image .custom-header-image:before {
 		height: 33%;
 	}
 
-	.admin-bar.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
-	.admin-bar.home.blog:not(.no-header-image) .custom-header-image {
-		height: -webkit-calc(100vh - 32px);
+	.admin-bar.twentyseventeen-front-page.has-header-image .custom-header-image,
+	.admin-bar.home.blog.has-header-image .custom-header-image {
 		height: calc(100vh - 32px);
 	}
 
@@ -3867,8 +3877,8 @@ article.panel-placeholder {
 
 @media screen and ( min-width: 55em ) {
 
-	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
-	.home.blog:not(.no-header-image) .custom-header-image {
+	.twentyseventeen-front-page.has-header-image .custom-header-image,
+	.home.blog.has-header-image .custom-header-image {
 		background-attachment: fixed;
 	}
 
@@ -4027,8 +4037,8 @@ article.panel-placeholder {
 		padding: 0;
 	}
 
-	.twentyseventeen-front-page:not(.no-header-image) .site-branding,
-	.home.blog:not(.no-header-image) .site-branding {
+	.twentyseventeen-front-page.has-header-image .site-branding,
+	.home.blog.has-header-image .site-branding {
 		position: relative;
 	}
 
@@ -4066,8 +4076,8 @@ article.panel-placeholder {
 	body,
 	a,
 	.site-title a,
-	.twentyseventeen-front-page:not(.no-header-image) .site-title,
-	.twentyseventeen-front-page:not(.no-header-image) .site-title a {
+	.twentyseventeen-front-page.has-header-image .site-title,
+	.twentyseventeen-front-page.has-header-image .site-title a {
 		color: #222 !important; /* Make sure color schemes don't affect to print */
 	}
 
@@ -4075,7 +4085,7 @@ article.panel-placeholder {
 	h5,
 	blockquote,
 	.site-description,
-	.twentyseventeen-front-page:not(.no-header-image) .site-description,
+	.twentyseventeen-front-page.has-header-image .site-description,
 	.entry-meta,
 	.entry-meta a {
 		color: #777 !important; /* Make sure color schemes don't affect to print */

--- a/style.css
+++ b/style.css
@@ -1475,12 +1475,6 @@ body {
 	transition: margin-bottom 0.2s;
 }
 
-body.has-header-image .site-branding {
-	bottom: 0;
-	position: absolute;
-	width: 100%;
-}
-
 .site-branding a {
 	text-decoration: none;
 	-webkit-transition: opacity 0.2s;
@@ -1539,7 +1533,7 @@ body.has-header-image .site-description {
 	width: auto;
 }
 
-body.home.title-tagline-hidden:not(.no-header-image) .custom-logo-link img {
+body.home.title-tagline-hidden.has-header-image .custom-logo-link img {
 	max-height: 200px;
 	max-width: 100%;
 }
@@ -1562,7 +1556,11 @@ body:not(.title-tagline-hidden) .site-branding-text {
 	background-position: center center;
 	background-repeat: no-repeat;
 	background-size: cover;
-	height: 165px;
+	bottom: 0;
+	left: 0;
+	position: absolute;
+	right: 0;
+	top: 0;
 }
 
 .custom-header-image:before {
@@ -1580,13 +1578,7 @@ body:not(.title-tagline-hidden) .site-branding-text {
 	right: 0;
 }
 
-.twentyseventeen-front-page.has-header-image .custom-header-image,
-.home.blog.has-header-image .custom-header-image {
-	height: 0;
-	padding-top: 66%;
-}
-
-.no-header-image .custom-header-image {
+body:not(.has-header-image) .custom-header-image {
 	padding: 5% 0;
 }
 
@@ -3162,14 +3154,33 @@ article.panel-placeholder {
 		margin-bottom: 0;
 	}
 
+	.has-header-image.twentyseventeen-front-page .site-branding,
+	.has-header-image.home.blog .site-branding {
+		bottom: 0;
+		position: absolute;
+		width: 100%;
+	}
+
 	.custom-header-image {
 		height: 165px;
 		position: relative;
 		background-position: bottom;
 	}
 
-	.no-header-image .custom-header-image {
-		min-height: 20vh;
+	.has-header-image:not(.twentyseventeen-front-page):not(.home) .custom-header-image {
+		bottom: 0;
+		height: auto;
+		left: 0;
+		position: absolute;
+		right: 0;
+		top: 0;
+	}
+
+	.twentyseventeen-front-page.has-header-image .custom-header-image,
+	.home.blog.has-header-image .custom-header-image {
+		height: 0;
+		padding-top: 66%;
+		position: relative;
 	}
 
 	.custom-logo-link {
@@ -3177,11 +3188,11 @@ article.panel-placeholder {
 	}
 
 	.custom-logo-link img,
-	body.home.title-tagline-hidden:not(.no-header-image) .custom-logo-link img {
+	body.home.title-tagline-hidden.has-header-image .custom-logo-link img {
 		max-width: 350px;
 	}
 
-	.title-tagline-hidden.home:not(.no-header-image) .custom-logo-link img {
+	.title-tagline-hidden.home.has-header-image .custom-logo-link img {
 		max-height: 200px;
 	}
 
@@ -3433,26 +3444,26 @@ article.panel-placeholder {
 
 	/* Front Page */
 
-	.twentyseventeen-front-page:not(.no-header-image) .site-branding,
-	.home.blog:not(.no-header-image) .site-branding {
+	.twentyseventeen-front-page.has-header-image .site-branding,
+	.home.blog.has-header-image .site-branding {
 		margin-bottom: 70px;
 	}
 
-	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
-	.home.blog:not(.no-header-image) .custom-header-image {
+	.twentyseventeen-front-page.has-header-image .custom-header-image,
+	.home.blog.has-header-image .custom-header-image {
 		height: 1200px;
 		height: 100vh;
 		max-height: 100%;
 		padding: 10% 0;
 	}
 
-	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image:before,
-	.home.blog:not(.no-header-image) .custom-header-image:before {
+	.twentyseventeen-front-page.has-header-image .custom-header-image:before,
+	.home.blog.has-header-image .custom-header-image:before {
 		height: 33%;
 	}
 
-	.admin-bar.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
-	.admin-bar.home.blog:not(.no-header-image) .custom-header-image {
+	.admin-bar.twentyseventeen-front-page.has-header-image .custom-header-image,
+	.admin-bar.home.blog.has-header-image .custom-header-image {
 		height: calc(100vh - 32px);
 	}
 
@@ -3787,8 +3798,8 @@ article.panel-placeholder {
 
 @media screen and ( min-width: 55em ) {
 
-	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
-	.home.blog:not(.no-header-image) .custom-header-image {
+	.twentyseventeen-front-page.has-header-image .custom-header-image,
+	.home.blog.has-header-image .custom-header-image {
 		background-attachment: fixed;
 	}
 
@@ -3947,8 +3958,8 @@ article.panel-placeholder {
 		padding: 0;
 	}
 
-	.twentyseventeen-front-page:not(.no-header-image) .site-branding,
-	.home.blog:not(.no-header-image) .site-branding {
+	.twentyseventeen-front-page.has-header-image .site-branding,
+	.home.blog.has-header-image .site-branding {
 		position: relative;
 	}
 
@@ -3986,8 +3997,8 @@ article.panel-placeholder {
 	body,
 	a,
 	.site-title a,
-	.twentyseventeen-front-page:not(.no-header-image) .site-title,
-	.twentyseventeen-front-page:not(.no-header-image) .site-title a {
+	.twentyseventeen-front-page.has-header-image .site-title,
+	.twentyseventeen-front-page.has-header-image .site-title a {
 		color: #222 !important; /* Make sure color schemes don't affect to print */
 	}
 
@@ -3995,7 +4006,7 @@ article.panel-placeholder {
 	h5,
 	blockquote,
 	.site-description,
-	.twentyseventeen-front-page:not(.no-header-image) .site-description,
+	.twentyseventeen-front-page.has-header-image .site-description,
 	.entry-meta,
 	.entry-meta a {
 		color: #777 !important; /* Make sure color schemes don't affect to print */

--- a/style.css
+++ b/style.css
@@ -1521,8 +1521,7 @@ body {
 	transition: margin-bottom 0.2s;
 }
 
-.twentyseventeen-front-page:not(.no-header-image) .site-branding,
-.home.blog:not(.no-header-image) .site-branding {
+body.has-header-image .site-branding {
 	bottom: 0;
 	position: absolute;
 	width: 100%;
@@ -1556,10 +1555,8 @@ body {
 	color: #222;
 }
 
-.twentyseventeen-front-page:not(.no-header-image) .site-title,
-.twentyseventeen-front-page:not(.no-header-image) .site-title a,
-.home.blog:not(.no-header-image) .site-title,
-.home.blog:not(.no-header-image) .site-title a {
+body.has-header-image .site-title,
+body.has-header-image .site-title a {
 	color: #fff;
 }
 
@@ -1570,8 +1567,7 @@ body {
 	margin-bottom: 0;
 }
 
-.twentyseventeen-front-page:not(.no-header-image) .site-description,
-.home.blog:not(.no-header-image) .site-description {
+body.has-header-image .site-description {
 	color: #fff;
 	opacity: 0.8;
 }
@@ -3222,14 +3218,14 @@ article.panel-placeholder {
 	/* Site Branding */
 
 	.site-branding {
-		margin-bottom: 70px;
+		margin-bottom: 0;
 	}
 
 	.custom-header-image {
-		height: 750px;
-		height: 75vh;
+		height: 165px;
 		padding: 10% 0;
 		position: relative;
+		background-position: bottom;
 	}
 
 	.custom-header-image:before {
@@ -3242,7 +3238,7 @@ article.panel-placeholder {
 		bottom: 0;
 		content: "";
 		display: block;
-		height: 33%;
+		height: 100%;
 		left: 0;
 		position: absolute;
 		right: 0;
@@ -3513,11 +3509,21 @@ article.panel-placeholder {
 
 	/* Front Page */
 
+	.twentyseventeen-front-page:not(.no-header-image) .site-branding,
+	.home.blog:not(.no-header-image) .site-branding {
+		margin-bottom: 70px;
+	}
+
 	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
 	.home.blog:not(.no-header-image) .custom-header-image {
 		height: 1200px;
 		height: 100vh;
 		max-height: 100%;
+	}
+
+	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image:before,
+	.home.blog:not(.no-header-image) .custom-header-image:before {
+		height: 33%;
 	}
 
 	.admin-bar.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
@@ -3856,10 +3862,6 @@ article.panel-placeholder {
 }
 
 @media screen and ( min-width: 55em ) {
-
-	.custom-header-image {
-		background-attachment: fixed;
-	}
 
 	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
 	.home.blog:not(.no-header-image) .custom-header-image {

--- a/style.css
+++ b/style.css
@@ -1486,6 +1486,11 @@ body {
 	opacity: 0.7;
 }
 
+.has-header-image.twentyseventeen-front-page .site-branding,
+.has-header-image.home.blog .site-branding {
+	align-self: flex-end;
+}
+
 .site-title {
 	clear: none;
 	font-size: 24px;
@@ -1550,6 +1555,12 @@ body:not(.title-tagline-hidden) .site-branding-text {
 
 .custom-header {
 	position: relative;
+}
+
+.has-header-image.twentyseventeen-front-page .custom-header,
+.has-header-image.home.blog .custom-header {
+	display: flex;
+	min-height: 75vh;
 }
 
 .custom-header-image {
@@ -3157,8 +3168,15 @@ article.panel-placeholder {
 	.has-header-image.twentyseventeen-front-page .site-branding,
 	.has-header-image.home.blog .site-branding {
 		bottom: 0;
+		padding-top: 0;
 		position: absolute;
 		width: 100%;
+	}
+
+	.has-header-image.twentyseventeen-front-page .custom-header,
+	.has-header-image.home.blog .custom-header {
+		display: block;
+		min-height: 0;
 	}
 
 	.custom-header-image {


### PR DESCRIPTION
Riffing on @ryelle's PR #414.

I just updated the header styles to make sure it doesn't end up being too short on subpages. Also simplified the header classes a bit - the theme was adding both `.has-header-image` and `.no-header-image` classes, and for the most part the latter was used with `:not(.no-header-image)` so I removed it. 

See #413.
