### PR TITLE
Replacing dynamic header for blog posts page with static one.

### DIFF
--- a/index.php
+++ b/index.php
@@ -18,16 +18,10 @@
 get_header(); ?>
 
 <div class="wrap">
-	<?php
-	if ( is_home() && ! is_front_page() ) : ?>
-		<header class="page-header">
-			<h1 class="page-title"><?php single_post_title(); ?></h1>
-		</header>
-	<?php elseif ( is_home() ) : ?>
-		<header class="page-header">
-			<h2 class="page-title"><?php echo get_the_title( get_option( 'page_for_posts' ) ); ?></h2>
-		</header>
-	<?php endif; ?>
+	<header class="page-header">
+		<h2 class="page-title"><?php _e( 'Posts', 'twentyseventeen' ); ?></h2>
+	</header>
+
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main" role="main">
 

--- a/index.php
+++ b/index.php
@@ -18,9 +18,15 @@
 get_header(); ?>
 
 <div class="wrap">
+	<?php if ( is_home() && ! is_front_page() ) : ?>
+		<header class="page-header">
+			<h1 class="page-title"><?php single_post_title(); ?></h1>
+		</header>
+	<?php else : ?>
 	<header class="page-header">
 		<h2 class="page-title"><?php _e( 'Posts', 'twentyseventeen' ); ?></h2>
 	</header>
+	<?php endif; ?>
 
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main" role="main">


### PR DESCRIPTION
Now:
- Front page with posts says "Posts".
- Static front page shows page title.

Fixes #437. Replaces #477.
