### PR TITLE
Updating header styles for custom header on all pages, redux

### DIFF
--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -14,6 +14,7 @@
 			$sidebar = $body.find( '#secondary' ),
 			$entryContent = $body.find( '.entry-content' ),
 			$formatQuote = $body.find( '.format-quote blockquote' ),
+			isFrontPage = $body.hasClass( 'twentyseventeen-front-page' ) || $body.hasClass( 'home blog' ),
 			navigationFixedClass = 'site-navigation-fixed',
 			navigationHeight,
 			navigationOuterHeight,
@@ -49,7 +50,7 @@
 			if ( navIsNotTooTall ) {
 
 				// When there's a custom header image, the header offset includes the height of the navigation
-				if ( $customHeaderImage.length ) {
+				if ( isFrontPage && $customHeaderImage.length ) {
 					headerOffset = $customHeader.innerHeight() - navigationOuterHeight;
 				} else {
 					headerOffset = $customHeader.innerHeight();
@@ -75,9 +76,14 @@
 	 */
 	function adjustHeaderHeight() {
 		if ( 'none' === $menuToggle.css( 'display' ) ) {
-			$branding.css( 'margin-bottom', navigationOuterHeight );
+			// The margin should be applied to different elements on front-page or home vs interior pages.
+			if ( isFrontPage ) {
+				$branding.css( 'margin-bottom', navigationOuterHeight );
+			} else {
+				$customHeader.css( 'margin-bottom', navigationOuterHeight );
+			}
 		} else {
-			$branding.css( 'margin-bottom', '0' );
+			$customHeader.css( 'margin-bottom', '0' );
 		}
 	}
 

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -86,6 +86,7 @@
 
 		} else {
 			$customHeader.css( 'margin-bottom', '0' );
+			$branding.css( 'margin-bottom', '0' );
 		}
 	}
 

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -76,12 +76,14 @@
 	 */
 	function adjustHeaderHeight() {
 		if ( 'none' === $menuToggle.css( 'display' ) ) {
+
 			// The margin should be applied to different elements on front-page or home vs interior pages.
 			if ( isFrontPage ) {
 				$branding.css( 'margin-bottom', navigationOuterHeight );
 			} else {
 				$customHeader.css( 'margin-bottom', navigationOuterHeight );
 			}
+
 		} else {
 			$customHeader.css( 'margin-bottom', '0' );
 		}

--- a/components/header/header-image.php
+++ b/components/header/header-image.php
@@ -11,38 +11,29 @@
 ?>
 <div class="custom-header">
 	<?php
+	$header_image = get_header_image();
 
-		// If front page.
-		if ( twentyseventeen_is_frontpage() || ( is_home() && is_front_page() ) ) :
+	// Check if Custom Header image has been added.
+	if ( ! empty( $header_image ) ) : ?>
 
-			// Check if Custom Header image has been added.
-			$header_image = get_header_image();
-			if ( ! empty( $header_image ) ) : ?>
+		<div class="custom-header-image" style="background-image: url(<?php echo esc_url( $header_image ); ?>)"></div>
+		<?php get_template_part( 'components/header/site', 'branding' ); ?>
 
-				<div class="custom-header-image" style="background-image: url(<?php echo esc_url( $header_image ); ?>)"></div>
-				<?php get_template_part( 'components/header/site', 'branding' ); ?>
+	<?php elseif ( twentyseventeen_is_frontpage() && has_post_thumbnail() ) :
+		// If not, fall back to front page's featured image, only on the front page.
+		$post_thumbnail_id = get_post_thumbnail_id( $post->ID );
+		$thumbnail_attributes = wp_get_attachment_image_src( $post_thumbnail_id, 'twentyseventeen-featured-image' );
+		?>
 
-			<?php elseif ( twentyseventeen_is_frontpage() && has_post_thumbnail() ) :
-				// If not, fall back to front page's featured image.
-				$post_thumbnail_id = get_post_thumbnail_id( $post->ID );
-				$thumbnail_attributes = wp_get_attachment_image_src( $post_thumbnail_id, 'twentyseventeen-featured-image' );
-				?>
+		<div class="custom-header-image" style="background-image: url(<?php echo esc_url( $thumbnail_attributes[0] ); ?>)"></div>
+		<?php get_template_part( 'components/header/site', 'branding' ); ?>
 
-				<div class="custom-header-image" style="background-image: url(<?php echo esc_url( $thumbnail_attributes[0] ); ?>)"></div>
-				<?php get_template_part( 'components/header/site', 'branding' ); ?>
+	<?php else : ?>
+		<?php // Otherwise, show a blank header. ?>
+		<div class="custom-header-simple">
+			<?php get_template_part( 'components/header/site', 'branding' ); ?>
+		</div><!-- .custom-header-simple -->
 
-			<?php else : ?>
-				<?php // Otherwise, show a blank header. ?>
-				<div class="custom-header-simple">
-					<?php get_template_part( 'components/header/site', 'branding' ); ?>
-				</div><!-- .custom-header-simple -->
-
-			<?php endif;
-		// If not the front page, show a shorter plain header.
-		else : ?>
-			<div class="custom-header-simple">
-				<?php get_template_part( 'components/header/site', 'branding' ); ?>
-			</div><!-- .custom-header-simple -->
 	<?php endif; ?>
 
 </div><!-- .custom-header -->

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -17,7 +17,7 @@
 function twentyseventeen_custom_header_setup() {
 	add_theme_support( 'custom-header', apply_filters( 'twentyseventeen_custom_header_args', array(
 		'default-image'      => get_parent_theme_file_uri( '/assets/images/header.jpg' ),
-		'default-text-color' => '222222',
+		'default-text-color' => 'ffffff',
 		'width'              => 2000,
 		'height'             => 1200,
 		'flex-height'        => true,

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -34,11 +34,6 @@ function twentyseventeen_body_classes( $classes ) {
 		$classes[] = 'twentyseventeen-front-page';
 	}
 
-	// Add class if no custom header or featured images.
-	if ( ! has_header_image() && ( ! has_post_thumbnail() || is_home() ) ) {
-		$classes[] = 'no-header-image';
-	}
-
 	// Add a class if there is a featured image or custom header.
 	if ( has_header_image() || ( has_post_thumbnail() && twentyseventeen_is_frontpage() ) ) {
 		$classes[] = 'has-header-image';

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -39,6 +39,11 @@ function twentyseventeen_body_classes( $classes ) {
 		$classes[] = 'no-header-image';
 	}
 
+	// Add a class if there is a featured image or custom header.
+	if ( has_header_image() || ( has_post_thumbnail() && twentyseventeen_is_frontpage() ) ) {
+		$classes[] = 'has-header-image';
+	}
+
 	// Add class if sidebar is used.
 	if ( is_active_sidebar( 'sidebar-1' ) && ! is_page() ) {
 		$classes[] = 'has-sidebar';

--- a/style.css
+++ b/style.css
@@ -1521,12 +1521,6 @@ body {
 	transition: margin-bottom 0.2s;
 }
 
-body.has-header-image .site-branding {
-	bottom: 0;
-	position: absolute;
-	width: 100%;
-}
-
 .site-branding a {
 	text-decoration: none;
 	-webkit-transition: opacity 0.2s;
@@ -1536,6 +1530,11 @@ body.has-header-image .site-branding {
 .site-branding a:hover,
 .site-branding a:focus {
 	opacity: 0.7;
+}
+
+.has-header-image.twentyseventeen-front-page .site-branding,
+.has-header-image.home.blog .site-branding {
+	align-self: flex-end;
 }
 
 .site-title {
@@ -1585,7 +1584,7 @@ body.has-header-image .site-description {
 	width: auto;
 }
 
-body.home.title-tagline-hidden:not(.no-header-image) .custom-logo-link img {
+body.home.title-tagline-hidden.has-header-image .custom-logo-link img {
 	max-height: 200px;
 	max-width: 100%;
 }
@@ -1604,12 +1603,23 @@ body:not(.title-tagline-hidden) .site-branding-text {
 	position: relative;
 }
 
+.has-header-image.twentyseventeen-front-page .custom-header,
+.has-header-image.home.blog .custom-header {
+	display: flex;
+	min-height: 300px;
+	min-height: 75vh;
+}
+
 .custom-header-image {
 	background-position: center center;
 	background-repeat: no-repeat;
 	-webkit-background-size: cover;
 	background-size: cover;
-	height: 165px;
+	bottom: 0;
+	left: 0;
+	position: absolute;
+	right: 0;
+	top: 0;
 }
 
 .custom-header-image:before {
@@ -1627,13 +1637,11 @@ body:not(.title-tagline-hidden) .site-branding-text {
 	right: 0;
 }
 
-.twentyseventeen-front-page.has-header-image .custom-header-image,
-.home.blog.has-header-image .custom-header-image {
-	height: 0;
-	padding-top: 66%;
+.has-header-image:not(.twentyseventeen-front-page):not(.home) .custom-header-image {
+	background-position: center bottom;
 }
 
-.no-header-image .custom-header-image {
+body:not(.has-header-image) .custom-header-image {
 	padding: 5% 0;
 }
 
@@ -3241,14 +3249,39 @@ article.panel-placeholder {
 		margin-bottom: 0;
 	}
 
+	.has-header-image.twentyseventeen-front-page .site-branding,
+	.has-header-image.home.blog .site-branding {
+		bottom: 0;
+		padding-top: 0;
+		position: absolute;
+		width: 100%;
+	}
+
+	.has-header-image.twentyseventeen-front-page .custom-header,
+	.has-header-image.home.blog .custom-header {
+		display: block;
+		min-height: 0;
+	}
+
 	.custom-header-image {
 		height: 165px;
 		position: relative;
-		background-position: bottom;
 	}
 
-	.no-header-image .custom-header-image {
-		min-height: 20vh;
+	.has-header-image:not(.twentyseventeen-front-page):not(.home) .custom-header-image {
+		bottom: 0;
+		height: auto;
+		left: 0;
+		position: absolute;
+		right: 0;
+		top: 0;
+	}
+
+	.twentyseventeen-front-page.has-header-image .custom-header-image,
+	.home.blog.has-header-image .custom-header-image {
+		height: 0;
+		padding-top: 66%;
+		position: relative;
 	}
 
 	.custom-logo-link {
@@ -3256,11 +3289,11 @@ article.panel-placeholder {
 	}
 
 	.custom-logo-link img,
-	body.home.title-tagline-hidden:not(.no-header-image) .custom-logo-link img {
+	body.home.title-tagline-hidden.has-header-image .custom-logo-link img {
 		max-width: 350px;
 	}
 
-	.title-tagline-hidden.home:not(.no-header-image) .custom-logo-link img {
+	.title-tagline-hidden.home.has-header-image .custom-logo-link img {
 		max-height: 200px;
 	}
 
@@ -3512,27 +3545,26 @@ article.panel-placeholder {
 
 	/* Front Page */
 
-	.twentyseventeen-front-page:not(.no-header-image) .site-branding,
-	.home.blog:not(.no-header-image) .site-branding {
+	.twentyseventeen-front-page.has-header-image .site-branding,
+	.home.blog.has-header-image .site-branding {
 		margin-bottom: 70px;
 	}
 
-	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
-	.home.blog:not(.no-header-image) .custom-header-image {
+	.twentyseventeen-front-page.has-header-image .custom-header-image,
+	.home.blog.has-header-image .custom-header-image {
 		height: 1200px;
 		height: 100vh;
 		max-height: 100%;
 		padding: 10% 0;
 	}
 
-	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image:before,
-	.home.blog:not(.no-header-image) .custom-header-image:before {
+	.twentyseventeen-front-page.has-header-image .custom-header-image:before,
+	.home.blog.has-header-image .custom-header-image:before {
 		height: 33%;
 	}
 
-	.admin-bar.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
-	.admin-bar.home.blog:not(.no-header-image) .custom-header-image {
-		height: -webkit-calc(100vh - 32px);
+	.admin-bar.twentyseventeen-front-page.has-header-image .custom-header-image,
+	.admin-bar.home.blog.has-header-image .custom-header-image {
 		height: calc(100vh - 32px);
 	}
 
@@ -3867,8 +3899,8 @@ article.panel-placeholder {
 
 @media screen and ( min-width: 55em ) {
 
-	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
-	.home.blog:not(.no-header-image) .custom-header-image {
+	.twentyseventeen-front-page.has-header-image .custom-header-image,
+	.home.blog.has-header-image .custom-header-image {
 		background-attachment: fixed;
 	}
 
@@ -4027,8 +4059,8 @@ article.panel-placeholder {
 		padding: 0;
 	}
 
-	.twentyseventeen-front-page:not(.no-header-image) .site-branding,
-	.home.blog:not(.no-header-image) .site-branding {
+	.twentyseventeen-front-page.has-header-image .site-branding,
+	.home.blog.has-header-image .site-branding {
 		position: relative;
 	}
 
@@ -4066,8 +4098,8 @@ article.panel-placeholder {
 	body,
 	a,
 	.site-title a,
-	.twentyseventeen-front-page:not(.no-header-image) .site-title,
-	.twentyseventeen-front-page:not(.no-header-image) .site-title a {
+	.twentyseventeen-front-page.has-header-image .site-title,
+	.twentyseventeen-front-page.has-header-image .site-title a {
 		color: #222 !important; /* Make sure color schemes don't affect to print */
 	}
 
@@ -4075,7 +4107,7 @@ article.panel-placeholder {
 	h5,
 	blockquote,
 	.site-description,
-	.twentyseventeen-front-page:not(.no-header-image) .site-description,
+	.twentyseventeen-front-page.has-header-image .site-description,
 	.entry-meta,
 	.entry-meta a {
 		color: #777 !important; /* Make sure color schemes don't affect to print */

--- a/style.css
+++ b/style.css
@@ -1562,6 +1562,26 @@ body:not(.title-tagline-hidden) .site-branding-text {
 	background-position: center center;
 	background-repeat: no-repeat;
 	background-size: cover;
+	height: 165px;
+}
+
+.custom-header-image:before {
+	/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#000000+0,000000+100&0+0,0.3+75 */
+	background: -moz-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* FF3.6-15 */
+	background: -webkit-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* Chrome10-25,Safari5.1-6 */
+	background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#00000000", endColorstr="#4d000000", GradientType=0); /* IE6-9 */
+	bottom: 0;
+	content: "";
+	display: block;
+	height: 100%;
+	left: 0;
+	position: absolute;
+	right: 0;
+}
+
+.twentyseventeen-front-page.has-header-image .custom-header-image,
+.home.blog.has-header-image .custom-header-image {
 	height: 0;
 	padding-top: 66%;
 }
@@ -3144,24 +3164,8 @@ article.panel-placeholder {
 
 	.custom-header-image {
 		height: 165px;
-		padding: 10% 0;
 		position: relative;
 		background-position: bottom;
-	}
-
-	.custom-header-image:before {
-		/* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#000000+0,000000+100&0+0,0.3+75 */
-		background: -moz-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* FF3.6-15 */
-		background: -webkit-linear-gradient(to top, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* Chrome10-25,Safari5.1-6 */
-		background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.3) 75%, rgba(0, 0, 0, 0.3) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
-		filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#00000000", endColorstr="#4d000000", GradientType=0); /* IE6-9 */
-		bottom: 0;
-		content: "";
-		display: block;
-		height: 100%;
-		left: 0;
-		position: absolute;
-		right: 0;
 	}
 
 	.no-header-image .custom-header-image {
@@ -3439,6 +3443,7 @@ article.panel-placeholder {
 		height: 1200px;
 		height: 100vh;
 		max-height: 100%;
+		padding: 10% 0;
 	}
 
 	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image:before,

--- a/style.css
+++ b/style.css
@@ -1475,8 +1475,7 @@ body {
 	transition: margin-bottom 0.2s;
 }
 
-.twentyseventeen-front-page:not(.no-header-image) .site-branding,
-.home.blog:not(.no-header-image) .site-branding {
+body.has-header-image .site-branding {
 	bottom: 0;
 	position: absolute;
 	width: 100%;
@@ -1510,10 +1509,8 @@ body {
 	color: #222;
 }
 
-.twentyseventeen-front-page:not(.no-header-image) .site-title,
-.twentyseventeen-front-page:not(.no-header-image) .site-title a,
-.home.blog:not(.no-header-image) .site-title,
-.home.blog:not(.no-header-image) .site-title a {
+body.has-header-image .site-title,
+body.has-header-image .site-title a {
 	color: #fff;
 }
 
@@ -1524,8 +1521,7 @@ body {
 	margin-bottom: 0;
 }
 
-.twentyseventeen-front-page:not(.no-header-image) .site-description,
-.home.blog:not(.no-header-image) .site-description {
+body.has-header-image .site-description {
 	color: #fff;
 	opacity: 0.8;
 }
@@ -3143,14 +3139,14 @@ article.panel-placeholder {
 	/* Site Branding */
 
 	.site-branding {
-		margin-bottom: 70px;
+		margin-bottom: 0;
 	}
 
 	.custom-header-image {
-		height: 750px;
-		height: 75vh;
+		height: 165px;
 		padding: 10% 0;
 		position: relative;
+		background-position: bottom;
 	}
 
 	.custom-header-image:before {
@@ -3162,7 +3158,7 @@ article.panel-placeholder {
 		bottom: 0;
 		content: "";
 		display: block;
-		height: 33%;
+		height: 100%;
 		left: 0;
 		position: absolute;
 		right: 0;
@@ -3433,11 +3429,21 @@ article.panel-placeholder {
 
 	/* Front Page */
 
+	.twentyseventeen-front-page:not(.no-header-image) .site-branding,
+	.home.blog:not(.no-header-image) .site-branding {
+		margin-bottom: 70px;
+	}
+
 	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
 	.home.blog:not(.no-header-image) .custom-header-image {
 		height: 1200px;
 		height: 100vh;
 		max-height: 100%;
+	}
+
+	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image:before,
+	.home.blog:not(.no-header-image) .custom-header-image:before {
+		height: 33%;
 	}
 
 	.admin-bar.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
@@ -3775,10 +3781,6 @@ article.panel-placeholder {
 }
 
 @media screen and ( min-width: 55em ) {
-
-	.custom-header-image {
-		background-attachment: fixed;
-	}
 
 	.twentyseventeen-front-page:not(.no-header-image) .custom-header-image,
 	.home.blog:not(.no-header-image) .custom-header-image {


### PR DESCRIPTION
Redoing fixes I made in #474 - I screwed up that PR, so trying again fresh:

Riffing on @ryelle's PR #414.

I just updated the header styles to make sure it doesn't end up being too short on subpages. Also simplified the header classes a bit - the theme was adding both .has-header-image and .no-header-image classes, and for the most part the latter was used with :not(.no-header-image) so I removed it.

See #413.
