### PR TITLE
Fix narrow header in blog panel 

### DIFF
--- a/rtl.css
+++ b/rtl.css
@@ -90,6 +90,14 @@ input[type="checkbox"] {
 	right: auto;
 }
 
+/* Front Page */
+
+.twentyseventeen-panel .recent-posts .entry-header .edit-link {
+	margin-left: 0;
+	margin-right: 1.0em;
+}
+
+
 /* Blog, Archive, Search */
 
 .blog .entry-meta a.post-edit-link,

--- a/style.css
+++ b/style.css
@@ -1702,6 +1702,14 @@ body:not(.title-tagline-hidden) .site-branding-text {
 	text-transform: none;
 }
 
+.twentyseventeen-panel .recent-posts .entry-header .edit-link {
+	color: #222;
+	display: inline-block;
+	font-size: 11px;
+	font-size: 0.6875rem;
+	margin-left: 1.0em;
+}
+
 /*--------------------------------------------------------------
 ## Regular Content
 --------------------------------------------------------------*/
@@ -3559,7 +3567,9 @@ article.panel-placeholder {
 	}
 
 	.panel-content .recent-posts .entry-header,
-	.panel-content .recent-posts .entry-content {
+	.page-two-column #primary .panel-content .recent-posts .entry-header,
+	.panel-content .recent-posts .entry-content,
+	.page-two-column #primary .panel-content .recent-posts .entry-content {
 		float: none;
 		width: 100%;
 	}


### PR DESCRIPTION
When the page layout is set to two columns, the blog panel on the front page is mucking up the headers:

![Image](https://cldup.com/F5FzTN8Z_L-3000x3000.png)

This PR makes sure the blog panel doesn't incorrectly inherit the two column styles.
